### PR TITLE
feat: implementar listado de oficinas y tipos de documento

### DIFF
--- a/src/pages/sistema/OficinasPage.vue
+++ b/src/pages/sistema/OficinasPage.vue
@@ -1,0 +1,50 @@
+<template>
+  <ListPage :titulo="titulo" :table="table" />
+</template>
+
+<script setup>
+import { useRouter } from "vue-router";
+import ListPage from "src/components/ListPage.vue";
+
+const router = useRouter();
+
+const titulo = {
+  title: "Oficinas",
+  icon: "list",
+  buttons: [
+    {
+      label: "Agregar Oficina",
+      icon: "add",
+      route: "/oficina/nuevo",
+    },
+  ],
+};
+
+const columns = [
+  {
+    name: "abreviatura",
+    label: "Abreviatura",
+    align: "left",
+    field: "abreviatura",
+    sortable: true,
+  },
+  {
+    name: "nombre",
+    label: "Nombre",
+    align: "left",
+    field: "nombre",
+    sortable: true,
+  },
+  { name: "actions", label: "Acciones", align: "center" },
+];
+
+const editOficina = (row) => {
+  router.push(`/oficina/editar/${row.id}`);
+};
+
+const table = {
+  endpoint: "/api/base/oficinas/",
+  columns,
+  handleEdit: editOficina,
+};
+</script>

--- a/src/pages/sistema/TiposDocumentoPage.vue
+++ b/src/pages/sistema/TiposDocumentoPage.vue
@@ -1,0 +1,43 @@
+<template>
+  <ListPage :titulo="titulo" :table="table" />
+</template>
+
+<script setup>
+import { useRouter } from "vue-router";
+import ListPage from "src/components/ListPage.vue";
+
+const router = useRouter();
+
+const titulo = {
+  title: "Lista de tipos de documento",
+  icon: "list",
+  buttons: [
+    {
+      label: "Crear nuevo tipo de documento",
+      icon: "add",
+      route: "/tipos-documento/nuevo",
+    },
+  ],
+};
+
+const columns = [
+  {
+    name: "nombre",
+    label: "Nombre",
+    align: "left",
+    field: "nombre",
+    sortable: true,
+  },
+  { name: "actions", label: "Acciones", align: "center" },
+];
+
+const editTipoDocumento = (row) => {
+  router.push(`/tipos-documento/editar/${row.id}`);
+};
+
+const table = {
+  endpoint: "/api/base/tipos-documento/",
+  columns,
+  handleEdit: editTipoDocumento,
+};
+</script>

--- a/src/router/routes.js
+++ b/src/router/routes.js
@@ -2,7 +2,11 @@ const routes = [
   {
     path: '/',
     component: () => import('layouts/MainLayout.vue'),
-    children: [{ path: '', component: () => import('pages/IndexPage.vue') }],
+    children: [
+      { path: '', component: () => import('pages/IndexPage.vue') },
+      { path: 'oficinas', component: () => import('pages/sistema/OficinasPage.vue') },
+      { path: 'tipos-documento', component: () => import('pages/sistema/TiposDocumentoPage.vue') },
+    ],
     meta: { requiresAuth: true },
   },
   {
@@ -10,7 +14,6 @@ const routes = [
     component: () => import('layouts/AuthLayout.vue'),
     children: [{ path: '', component: () => import('pages/LoginPage.vue') }],
   },
-
   {
     path: '/test',
     component: () => import('layouts/MainLayout.vue'),
@@ -21,7 +24,7 @@ const routes = [
       }
     ]
   },
-  
+
   {
     path: '/:catchAll(.*)*',
     component: () => import('layouts/MainLayout.vue'),


### PR DESCRIPTION
### **Descripción**
Se crearon las páginas para mostrar el listado de oficinas y de tipos de documentos respectivamente.

### **Cambios técnicos**
Se crearon los archivos:

- `src/sistema/OficinasPage.vue`
- `src/sistema/TiposDocumentoPage.vue`

Ambos usan los componentes previamente implementados, como `ListPage.vue`. Se conectan al backend por medio de endpoints, y cabe señalar que se necesita que el usuario actual sea parte del grupo 'Administradores'.

### **Capturas de pantalla**
![image](https://github.com/user-attachments/assets/a6618ee0-ee25-4ec3-8e7f-81dcb1d4e1e0)
![image](https://github.com/user-attachments/assets/89656f22-c527-4a37-bfea-a7771369cc39)


### **Issue relacionado**
#6 