### PR TITLE
Feat crear pagina de opciones

### DIFF
--- a/src/pages/sistema/OpcionPage.vue
+++ b/src/pages/sistema/OpcionPage.vue
@@ -1,0 +1,47 @@
+<template>
+  <q-page padding>
+    <PageTitle title="Opciones del sistema" icon="settings" />
+    <div class="q-pa-md">
+      <div class="row q-col-gutter-lg">
+        <div class="col-6 q-gutter-md">
+          <SimpleTitle title="General" />
+
+          <APIEditInline
+            v-for="opcion in opciones"
+            :key="opcion.clave"
+            :clave="opcion.clave"
+            :label="opcion.label"
+            :tipo="opcion.tipo"
+            :opciones="opcion.options"
+          />
+        </div>
+      </div>
+    </div>
+  </q-page>
+</template>
+
+<script setup>
+import { ref } from 'vue'
+import PageTitle from 'src/components/PageTitle.vue'
+import SimpleTitle from 'src/components/SimpleTitle.vue'
+import APIEditInline from 'src/components/APIEditInline.vue'
+
+const opciones = ref([
+  { clave: 'tipo_entidad', label: 'Tipo de Entidad' },
+  { clave: 'entidad', label: 'Entidad' },
+  { clave: 'direccion', label: 'Dirección' },
+  { clave: 'ubicacion', label: 'Ubicación' },
+  { clave: 'nombre_anio', label: 'Nombre del año' },
+  { clave: 'anio_actual', label: 'Año actual' },
+  { clave: 'logo', label: 'Logo' },
+  {
+    clave: 'numeracion',
+    label: 'Tipo de numeración',
+    tipo: 'combo',
+    options: [
+      { value: 'oficina', label: 'Por oficina' },
+      { value: 'usuario', label: 'Por usuario' },
+    ],
+  },
+])
+</script>

--- a/src/router/routes.js
+++ b/src/router/routes.js
@@ -11,6 +11,22 @@ const routes = [
     children: [{ path: '', component: () => import('pages/LoginPage.vue') }],
   },
 
+  // SISTEMA
+
+  {
+    path: '/',
+    component: () => import('layouts/MainLayout.vue'),
+    children: [
+      {
+        path: 'opciones',
+        component: () => import('pages/sistema/OpcionPage.vue'),
+        props: true,
+        meta: { requireLogin: true, groups: ['Administradores'] },
+      },
+    ],
+  },
+
+  // TEST
   {
     path: '/test',
     component: () => import('layouts/MainLayout.vue'),
@@ -18,10 +34,10 @@ const routes = [
       {
         path: '',
         component: () => import('pages/Test.vue'),
-      }
-    ]
+      },
+    ],
   },
-  
+
   {
     path: '/:catchAll(.*)*',
     component: () => import('layouts/MainLayout.vue'),


### PR DESCRIPTION
## Crear página de opciones

Implemente la página de opciones solicitada en el issue.
### Cambios realizados:
- Se agrego la pagina `OpcionPage.vue`en `pages/sistema` 
- se añadio el enlace de opciones a `router.js`
![Captura desde 2025-06-02 15-05-20](https://github.com/user-attachments/assets/bf6d8915-8155-406d-83e3-79b04ebfc229)
