### PR TITLE
feat/añadir 'depende de' a EditarOficina

### DIFF
--- a/src/pages/sistema/EditarOficina.vue
+++ b/src/pages/sistema/EditarOficina.vue
@@ -1,34 +1,143 @@
 <template>
-  <DynamicPage :titulo="titulo" :form="form" />
+  <q-page padding>
+    <PageTitle
+      title="Editar Oficina"
+      icon="edit"
+      :buttons="[
+        {
+          label: 'Ver todas las oficinas',
+          route: '/oficinas',
+          icon: 'list',
+        },
+      ]"
+    />
+    <div class="q-pa-md">
+      <q-form @submit="submitForm" class="q-gutter-md">
+        <div class="row q-col-gutter-lg">
+          <div class="col-12 q-gutter-md">
+            <q-input
+              outlined
+              v-model="info.nombre"
+              label="Nombre"
+              maxlength="150"
+              :error-message="errores_texto.nombre"
+              :error="errores.nombre"
+              type="text"
+            />
+            <q-input
+              outlined
+              v-model="info.abreviatura"
+              label="Abreviatura"
+              maxlength="255"
+              :error-message="errores_texto.abreviatura"
+              :error="errores.abreviatura"
+              type="text"
+            />
+            <APISelect
+              v-model="info.depende_de"
+              field="nombre"
+              label="Depende de"
+              url="/api/base/oficinas/"
+              :error-message="errores_texto.depende_de"
+              :error="errores.depende_de"
+              :defaultIds="[info.depende_de]"
+            />
+            <q-btn type="submit" label="Guardar" color="primary" icon="save" />
+          </div>
+        </div>
+      </q-form>
+    </div>
+  </q-page>
 </template>
 
 <script setup>
-import DynamicPage from "src/components/DynamicPage.vue";
+import { reactive, onMounted } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+import { api } from 'src/boot/axios'
+import PageTitle from 'src/components/PageTitle.vue'
+import APISelect from 'src/components/APISelect.vue'
+import { useQuasar } from 'quasar'
 
-const props = defineProps({
-  id: {
-    type: String,
-    required: true,
-  },
-});
+const route = useRoute()
+const router = useRouter()
+const $q = useQuasar()
 
-const fields = [
-  { field: "nombre", label: "Nombre", type: "text" },
-  { field: "abreviatura", label: "Abreviatura", type: "text" },
-];
+const id = route.params.id
 
-const titulo = {
-  title: "Editar Oficina",
-  icon: "edit",
-  buttons: [
-    { label: "Ver todas las Oficinas", icon: "list", route: "/oficinas" },
-  ],
-};
+const info = reactive({
+  nombre: '',
+  abreviatura: '',
+})
 
-const form = {
-  endpoint: `/api/base/oficinas/${props.id}/`,
-  fields,
-  urlLista: "/oficinas",
-  isEdit: true,
-};
+const errores = reactive({})
+const errores_texto = reactive({})
+
+const fetchData = () => {
+  $q.loading.show({ message: 'Cargando informacion...' })
+  const url = `api/base/oficinas/${id}/`
+  api
+    .get(url, info)
+    .then((response) => {
+      Object.assign(info, response.data)
+      console.log(info)
+      $q.loading.hide()
+    })
+    .catch((error) => {
+      console.log(error)
+      $q.notify({
+        type: 'negative',
+        message: 'No se pudo conectar al servidor, por favor intente nuevamente en unos minutos.',
+      })
+      $q.loading.hide()
+    })
+}
+
+const saveData = () => {
+  const url = `api/base/oficinas/${id}/`
+  const postObj = {
+    ...info,
+    depende_de: info.depende_de ? info.depende_de.value.id : null,
+    depende_de_nombre: info.depende_de ? info.depende_de.value.nombre : null,
+  }
+  console.log(postObj)
+  api
+    .patch(url, postObj)
+    .then(() => {
+      const toPath = route.query.to || '/oficinas'
+      $q.notify({
+        type: 'info',
+        message: 'Oficina actualizada correctamente.',
+      })
+      $q.loading.hide()
+      router.push(toPath)
+    })
+    .catch((error) => {
+      if (error?.response?.status === 400) {
+        console.log(error.response.data)
+        for (const campo in error.response.data) {
+          errores[campo] = true
+          errores_texto[campo] = error.response.data[campo][0]
+        }
+        for (const campo in errores) {
+          if (!(campo in error.response.data)) {
+            errores[campo] = false
+          }
+        }
+      } else {
+        $q.notify({
+          type: 'negative',
+          message: 'No se pudo conectar al servidor, por favor intente nuevamente en unos minutos.',
+        })
+      }
+      $q.loading.hide()
+    })
+}
+
+const submitForm = (e) => {
+  if (e && e.preventDefault) e.preventDefault()
+  $q.loading.show({ message: 'Enviando informacion...' })
+  saveData()
+}
+
+onMounted(fetchData)
 </script>

--- a/src/router/routes.js
+++ b/src/router/routes.js
@@ -7,7 +7,7 @@ const routes = [
       { path: 'oficinas', component: () => import('pages/sistema/OficinasPage.vue') },
       { path: 'tipos-documento', component: () => import('pages/sistema/TiposDocumentoPage.vue') },
       { path: 'acciones', component: () => import('pages/sistema/AccionesPage.vue') },
-      { path: 'oficina/editar/:id', component: () => import('pages/sistema/EditarOficina.vue'), props: true },
+      { path: 'oficina/editar/:id', component: () => import('src/pages/sistema/EditarOficina.vue'), props: true },
       { path: 'tipos-documento/editar/:id', component: () => import('pages/sistema/EditarTipoDocumento.vue'), props: true },
       { path: 'accion/editar/:id', component: () => import('pages/sistema/EditarAccion.vue'), props: true },
     ],


### PR DESCRIPTION
### **Descripción**
Se añadió el campo "Depende de" en la página de edición de oficinas.
### **Cambios Técnicos**
Se modifico el archivo `src/pages/sistema/EditarOficina.vue` por completo para poder ajustarse al uso de `src/components/ApiSelect.vue`. Los campos para editar el nombre y la abreviatura de la oficina funcionan, tanto para recuperar como para guardar los datos. 
### **Problemas** 

- El campo "Depende de" funciona perfectamente para guardar los datos modificados, pero no funciona al momento de recuperar la oficina, mostrando el `id` y no el `nombre` de la oficina, y en algunas ocasiones mostrando `oficinaCalca`.
- Al momento de seleccionar la misma oficina que se esta editando en el campo "Depende de" y guardarlo, hay un error al momento del `post`, sin embargo este error no se muestra de manera gráfica, es decir en un campo que indique :

> Una oficina no puede depender de sí misma.

O algo similar.

### **Capturas de Pantalla**
![image](https://github.com/user-attachments/assets/c4ee0421-d0c6-482a-84ac-8f7c23cd203e)
![image](https://github.com/user-attachments/assets/6cfe3b02-6aac-4f2e-8cb9-e0fda714a849)

### **Issue relacionado**
#14 