### PR TITLE
Fix/Al editar persona, evitar eliminar Asignacion de cargos

### DIFF
--- a/src/pages/sistema/CargosPage.vue
+++ b/src/pages/sistema/CargosPage.vue
@@ -28,6 +28,13 @@ const columns = [
     field: 'nombre',
     sortable: true,
   },
+  {
+    name: 'descripcion',
+    label: 'Descripción',
+    align: 'left',
+    field: 'descripcion',
+    sortable: true,
+  },
   { name: 'actions', label: 'Acciones', align: 'center' },
 ]
 

--- a/src/pages/sistema/PersonaForm.vue
+++ b/src/pages/sistema/PersonaForm.vue
@@ -49,10 +49,9 @@
               required
               v-model="info.celular"
               label="Celular"
-              maxlength="9"
+              maxlength="15"
               :error-message="errores_texto.celular"
               :error="errores.celular"
-              @keypress="soloNumeros"
             />
             <q-input
               v-if="!isEdit"
@@ -70,7 +69,7 @@
           <div class="col-6 q-gutter-md">
             <SimpleTitle v-if="!isEdit" title="Credenciales" />
             <q-input
-              v-if="!isEdit" 
+              v-if="!isEdit"
               outlined
               required
               type="password"
@@ -110,7 +109,9 @@
                         field="nombre"
                         :creatable="true"
                         create-endpoint="/api/base/cargos/"
-                        :create-fields="[{ field: 'nombre', label: 'Nombre del cargo', type: 'text' }]"
+                        :create-fields="[
+                          { field: 'nombre', label: 'Nombre del cargo', type: 'text' },
+                        ]"
                         dense
                       />
                     </div>
@@ -122,7 +123,9 @@
                         field="nombre"
                         :creatable="true"
                         create-endpoint="/api/base/oficinas/"
-                        :create-fields="[{ field: 'nombre', label: 'Nombre de oficina', type: 'text' }]"
+                        :create-fields="[
+                          { field: 'nombre', label: 'Nombre de oficina', type: 'text' },
+                        ]"
                         dense
                       />
                     </div>
@@ -245,7 +248,6 @@ const modifyData = async () => {
   }
 }
 
-
 const saveData = async () => {
   Object.keys(errores).forEach((k) => (errores[k] = false))
   Object.keys(errores_texto).forEach((k) => (errores_texto[k] = ''))
@@ -278,14 +280,13 @@ const submitForm = async () => {
     })
 
     router.push('/personas')
-  } else {  
+  } else {
     Notify.create({
       type: 'negative',
       message: 'Revisa los errores en el formulario.',
     })
   }
 }
-
 
 if (isEdit) {
   onMounted(fetchData)

--- a/src/pages/sistema/PersonaForm.vue
+++ b/src/pages/sistema/PersonaForm.vue
@@ -87,19 +87,7 @@
                 class="col-12"
               >
                 <div class="relative-position q-pa-sm bg-grey-1 rounded-borders">
-                  <q-btn
-                    v-if="info.asignaciones_cargo.length > 1"
-                    round
-                    unelevated
-                    color="negative"
-                    text-color="white"
-                    icon="delete"
-                    size="sm"
-                    class="absolute z-top"
-                    style="top: -5px; right: -5px"
-                    @click="removeAsignacion(index)"
-                    aria-label="Eliminar asignación"
-                  />
+                
                   <div class="row q-col-gutter-md">
                     <div class="col-6">
                       <APISelect
@@ -193,11 +181,6 @@ function addAsignacion() {
   info.asignaciones_cargo.push({ cargo: null, oficina: null })
 }
 
-function removeAsignacion(index) {
-  if (info.asignaciones_cargo.length > 1) {
-    info.asignaciones_cargo.splice(index, 1)
-  }
-}
 
 const errores = reactive({})
 const errores_texto = reactive({})

--- a/src/pages/sistema/PersonaForm.vue
+++ b/src/pages/sistema/PersonaForm.vue
@@ -55,6 +55,7 @@
               @keypress="soloNumeros"
             />
             <q-input
+              v-if="!isEdit"
               outlined
               required
               v-model="info.email"
@@ -67,18 +68,9 @@
           </div>
 
           <div class="col-6 q-gutter-md">
-            <SimpleTitle title="Credenciales" />
+            <SimpleTitle v-if="!isEdit" title="Credenciales" />
             <q-input
-              outlined
-              required
-              type="username"
-              v-model="info.username"
-              label="Usuario"
-              maxlength="150"
-              :error-message="errores_texto.username"
-              :error="errores.username"
-            />
-            <q-input
+              v-if="!isEdit" 
               outlined
               required
               type="password"
@@ -258,7 +250,9 @@ const saveData = async () => {
   Object.keys(errores).forEach((k) => (errores[k] = false))
   Object.keys(errores_texto).forEach((k) => (errores_texto[k] = ''))
   try {
-    await api.post(endpoint, info)
+    const payload = { ...info }
+    payload.username = info.documento
+    await api.post(endpoint, payload)
     return true
   } catch (error) {
     if (error.response && error.response.status === 400) {


### PR DESCRIPTION
### **Issues Relacionados**

Relacionado con #22:
- Se removió el boton para eliminar Asignaciones de cargo, así como el recuadro que este contenía y las funciones que usaba.

![image](https://github.com/user-attachments/assets/fcc71907-5afd-4bd6-8bf8-1595f3e85009)

Relacionado con #21:
- Se removió el campo para introducir el usuario en `src/sistema/PersonaForm.vue` al momento de la creación de personas.

![image](https://github.com/user-attachments/assets/98362aba-7771-4ebe-a2c2-7a58440b7360)

Relacionado con #24:
- Se incluyó un atributo `v-if` en el campo para introducir `password`, de tal manera que solo se muestre al momento de crear personas, mas no al editarlas.

![image](https://github.com/user-attachments/assets/41cdd871-5bd3-487d-a119-546277f0f5e4)
![image](https://github.com/user-attachments/assets/ee6ed30f-27c7-4b59-98ed-b3bc38a21930)
