### PR TITLE
Fix: en usuario nuevo - creacion  y validación de doble contraseña

### DIFF
--- a/src/pages/sistema/PersonaForm.vue
+++ b/src/pages/sistema/PersonaForm.vue
@@ -74,10 +74,25 @@
               required
               type="password"
               v-model="info.password"
-              label="Contraseña"
+              label="Contraseña"  
               maxlength="150"
               :error-message="errores_texto.password"
               :error="errores.password"
+
+
+            />
+            <q-input
+              v-if="!isEdit"
+              outlined
+              required
+              type="password"
+              v-model="info.password_repeat"
+              label="Contraseña otra vez"  
+              maxlength="150"
+              :error-message="errores_texto.password"
+              :error="errores.password"
+
+              
             />
             <SimpleTitle title="Asignaciones de Cargos" />
             <div class="row q-gutter-x-xs q-mt-md">
@@ -162,6 +177,7 @@ const titulo = reactive({
 const info = reactive({
   username: '',
   password: '',
+  password_repeat: '',
   email: '',
   nombres: '',
   apellidos: '',
@@ -255,7 +271,23 @@ const saveData = async () => {
 
 const submitForm = async () => {
   const success = isEdit ? await modifyData() : await saveData()
+  if (!isEdit) {
+    if (info.password !== info.password_repeat) {
+      Notify.create({
+        type: 'negative',
+        message: 'Las contraseñas no coinciden.',
+      })
+      return
+    }
 
+    if (info.password === info.documento) {
+      Notify.create({
+        type: 'negative',
+        message: 'La contraseña no puede ser igual al número de documento.',
+      })
+      return
+    }
+  }
   if (success) {
     Notify.create({
       type: 'positive',


### PR DESCRIPTION
Este PR resuelve la issue #27  la cual solicitaba agregar un segundo campo de contraseña en el formulario de creación de usuarios.

Los cambios realizados son:
Se añadió un segundo campo para repetir la contraseña (Contraseña otra vez).
Se validan los siguientes casos antes de enviar el formulario:
   ❌ Si las contraseñas no coinciden → se bloquea el guardado y se muestra mensaje.
   ❌ Si la contraseña es igual al número de documento → se bloquea el guardado y se muestra mensaje.

![image](https://github.com/user-attachments/assets/8fe19049-8670-492d-97c1-eed5840c102d)
![image](https://github.com/user-attachments/assets/39fe2bf5-4061-43d2-8948-bb1f82447930)
