### PR TITLE
Feat: Usar endpoints para obtener datos en la creacion de expedientes 

### DIFF
--- a/src/pages/tramite/NuevoDocumentoPage.vue
+++ b/src/pages/tramite/NuevoDocumentoPage.vue
@@ -5,7 +5,7 @@
       <q-form @submit.prevent="submitForm" class="q-gutter-md">
         <div class="row q-col-gutter-lg">
           <!-- INFORMACION -->
-          <div class="col-6 q-gutter-md">
+          <div class="col-4 q-gutter-md">
             <SimpleTitle title="Información" />
             <q-input
               outlined
@@ -25,6 +25,7 @@
               label="Fecha expediente"
               :error-message="errores_texto.fecha_expediente"
               :error="errores.fecha_expediente"
+              readonly
             />
             <q-input
               outlined
@@ -36,21 +37,45 @@
               :error="errores.remitente"
               readonly
             />
-            <q-input
+
+            <!-- Oficina: readonly, vacío con mensaje, o APISelect -->
+            <template v-if="oficinaOptions.readonly">
+              <q-input
+                outlined
+                required
+                v-model="info.oficina"
+                label="Oficina"
+                maxlength="255"
+                :error-message="errores_texto.oficina"
+                :error="errores.oficina"
+                readonly
+              />
+              <q-banner v-if="oficinaOptions.showNoOficinaMsg" class="q-mt-sm" color="negative" dense>
+                No tiene oficinas asignadas
+              </q-banner>
+            </template>
+            <q-select
+              v-else
               outlined
-              required
-              v-model="info.oficina"
               label="Oficina"
-              maxlength="255"
+              v-model="info.oficina"
+              :options="oficinaOptions.options"
+              option-label="label"
+              option-value="value"
               :error-message="errores_texto.oficina"
               :error="errores.oficina"
-              readonly
+              dense
+              clearable
             />
+
+            <!-- Tipo de documento -->
             <APISelect
               v-model="info.tipo_documento"
               label="Tipo de documento"
-              url="/api/tipos-documento/"
+              url="/api/base/tipos-documento/"
               field="nombre"
+              option-value="id"
+              option-label="nombre"
               dense
               :error-message="errores_texto.tipo_documento"
               :error="errores.tipo_documento"
@@ -78,7 +103,7 @@
           </div>
 
           <!-- Documento y destinatarios -->
-          <div class="col-6 q-gutter-md">
+          <div class="col-8 q-gutter-md">
             <SimpleTitle title="Documento" />
             <q-input
               outlined
@@ -86,6 +111,8 @@
               v-model="info.asunto"
               label="Asunto"
               maxlength="255"
+              type="textarea"
+              autogrow
               :error-message="errores_texto.asunto"
               :error="errores.asunto"
             />
@@ -94,8 +121,10 @@
               <APISelect
                 v-model="info.destinatarios[index]"
                 label="Destinatario"
-                url="/api/destinatarios/"
-                field="nombre"
+                url="/api/base/personas/"
+                field="nombre_completo"
+                option-value="id"
+                option-label="nombre_completo"
                 dense
                 :error-message="errores_texto[`destinatarios.${index}`]"
                 :error="errores[`destinatarios.${index}`]"
@@ -117,7 +146,7 @@
 </template>
 
 <script setup>
-import { reactive } from 'vue'
+import { reactive, onMounted, watch } from 'vue'
 import { Notify } from 'quasar'
 import { useRouter } from 'vue-router'
 import { api } from 'src/boot/axios'
@@ -127,14 +156,12 @@ import SimpleTitle from 'src/components/SimpleTitle.vue'
 
 const router = useRouter()
 
-// Título de la página
 const titulo = reactive({
   title: 'Nuevo Documento',
   icon: 'description',
   buttons: [{ label: 'Ver todos los Documentos', icon: 'list', route: '/documentos' }],
 })
 
-// Datos del formulario
 const info = reactive({
   expediente: '',
   fecha_expediente: '',
@@ -144,28 +171,111 @@ const info = reactive({
   numero: '',
   fecha_documento: '',
   asunto: '',
-  destinatarios: [null], // Soporta múltiples destinatarios
+  destinatarios: [null],
 })
 
-// Fecha actual
+const errores = reactive({})
+const errores_texto = reactive({})
+
+const endpoint = '/api/documentos/'
+
 const today = new Date().toISOString().slice(0, 10)
 info.fecha_expediente = today
 info.fecha_documento = today
 
-// Errores del formulario
-const errores = reactive({})
-const errores_texto = reactive({})
 
-// Endpoint para crear documento  
-const endpoint = '/api/documentos/'
+const oficinaOptions = reactive({
+  readonly: true,
+  showNoOficinaMsg: false,
+  options: [],
+})
+
+async function fetchPersonaActual() {
+  try {
+    const meRes = await api.get('/api/base/me/')
+    const personaId = meRes.data.persona.id
+    const res = await api.get(`/api/base/personas/${personaId}/`)
+    const persona = res.data
+
+    info.remitente = persona.nombres + ' ' + persona.apellidos
+
+    const oficinas = persona.asignaciones_cargo?.map(a => ({
+      label: a.oficina_nombre,
+      value: a.oficina,
+    })) || []
+
+    if (oficinas.length === 1) {
+      info.oficina = oficinas[0].label
+      oficinaOptions.readonly = true
+      oficinaOptions.showNoOficinaMsg = false
+    } else if (oficinas.length === 0) {
+      info.oficina = ''
+      oficinaOptions.readonly = true
+      oficinaOptions.showNoOficinaMsg = true
+    } else {
+      oficinaOptions.options = oficinas
+      oficinaOptions.readonly = false
+      oficinaOptions.showNoOficinaMsg = false
+    }
+  }  catch (error) {
+  console.error('Error al obtener persona actual:', error)
+  Notify.create({
+    type: 'negative',
+    message: 'No se pudo obtener los datos de la persona actual',
+  })
+}
+
+}
+
+
 
 function addDestinatario() {
   info.destinatarios.push(null)
 }
 
-// Enviar formulario
+async function fetchNumeroExpediente() {
+  try {
+    const res = await api.get('/api/tramite/expedientes/next-number/')
+    info.expediente = res.data.next_number
+  } catch (error) {
+    console.error('Error al obtener número de expediente:', error)
+    Notify.create({
+      type: 'negative',
+      message: 'No se pudo obtener el número de expediente',
+    })
+  }
+}
+
+async function fetchNumeroDocumento(tipo_id) {
+  if (!tipo_id) {
+    info.numero = ''
+    return
+  }
+
+  try {
+    const res = await api.get('/api/tramite/documentos/next-number/', {
+      params: { tipo_id }
+    })
+    info.numero = res.data.next_number
+  } catch (error) {
+    console.error('Error al obtener número de documento:', error)
+    Notify.create({
+      type: 'negative',
+      message: 'No se pudo obtener el número de documento',
+    })
+  }
+}
+
+onMounted(() => {
+  fetchNumeroExpediente()
+  fetchPersonaActual()
+})
+
+watch(() => info.tipo_documento, (newTipo) => {
+  fetchNumeroDocumento(newTipo?.id || newTipo)
+})
+
 const submitForm = async () => {
-  // Limpiar errores previos
   Object.keys(errores).forEach((k) => (errores[k] = false))
   Object.keys(errores_texto).forEach((k) => (errores_texto[k] = ''))
 


### PR DESCRIPTION
## Fix: Cambiar el layout de la pagina de creacion de documento #37  
## Feat: Usar endpoints para datos en expedientes  #38 

- Ajuste de columnas de **6/6 → 4/8** según diseño.
- Campo **Asunto** ahora es textarea (multilínea).
- **Fecha expediente** readonly.
- Se usan endpoints para:
  - Número de expediente y documento.
  - Datos del usuario actual y oficinas asignadas:
    -  1 oficina → readonly.
    -  Sin oficinas → readonly vacío + mensaje.
    -  Varias oficinas → select para elegir.

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/fba128fc-c747-4e5f-8e0e-ff8295ec7e7e" />

