### PR TITLE
fix/usar solo api/base/personas-con-oficina en NuevoDocumentoPage

### DIFF
--- a/src/pages/tramite/NuevoDocumentoPage.vue
+++ b/src/pages/tramite/NuevoDocumentoPage.vue
@@ -176,7 +176,7 @@
 </template>
 
 <script setup>
-import { computed, reactive, onMounted, watch } from 'vue'
+import { reactive, onMounted, watch } from 'vue'
 import { Notify } from 'quasar'
 import { useRouter } from 'vue-router'
 import { api } from 'src/boot/axios'
@@ -209,10 +209,14 @@ const errores_texto = reactive({})
 
 const endpoint = '/api/tramite/expedientes/completo/'
 
+const urlPersonasConOficina = '/api/base/personas-con-oficina/'
+
+/*
 const urlPersonasConOficina = computed(() => {
   if (!info.oficina) return '/api/base/personas-con-oficina/' // sin filtro si no hay oficina
   return `/api/base/personas-con-oficina/?oficina=${info.oficina.label}`
 })
+  */
 
 const today = new Date().toISOString().slice(0, 10)
 info.fecha_expediente = today


### PR DESCRIPTION
### **Descripción**
Se corrigió la página para crear un nuevo documento, haciendo que cualquier persona pueda ser destinatario, con su oficina correspondiente.
### **Cambios técnicos**
Se modifico la variable `urlPersonasConOficina` para que solo tenga el endpoint `/api/base/personas-con-oficina/`, dentro del archivo `src/pages/tramite/NuevoDocumentoPage.vue`.
### **Capturas de Pantalla**
<img width="630" height="327" alt="image" src="https://github.com/user-attachments/assets/f72ca158-ad35-4230-8299-5fa8aa39da1e" />
<img width="1601" height="741" alt="image" src="https://github.com/user-attachments/assets/ac55100b-a630-4f60-af24-f26afec489ee" />

### **Issue Relacionado**
#52 