### PR TITLE
Corregir ruta de acciones en la bandeja de entrada

### DIFF
--- a/src/pages/tramite/BandejaEntrada.vue
+++ b/src/pages/tramite/BandejaEntrada.vue
@@ -105,7 +105,7 @@ const table = computed(() => ({
     },
   ],
   getDynamicActions: async (row) => {
-    const response = await api.get(`/api/base/acciones/?documento=${row.id}`)
+    const response = await api.get(`/api/base/acciones-usuario/?idOficina=${row.id}`)
     return response.data.results.map((action) => ({
       label: action.nombre,
       action: (row) => {


### PR DESCRIPTION
### Fix: Corregir ruta de acciones en bandeja de entrada

Este PR #67 corrige el archivo `bandejaEntrada` en llamada a la API en `getDynamicActions` para utilizar el parámetro `idOficina` en lugar de `idDestinoDocumento` al obtener las acciones de la bandeja de entrada.

**Cambios realizados:**

Modificación de la URL en `getDynamicActions` para usar `idOficina`.

**Pruebas realizadas:**

Verificado que la bandeja de entrada carga correctamente las acciones usando idOficina y las devuelve como un objeto.
<img width="1835" height="938" alt="image" src="https://github.com/user-attachments/assets/9a76b18e-2c80-4944-b887-b26f90a039d8" />

