### PR TITLE
Agregar campo icono y loading al documento

### DIFF
--- a/src/pages/sistema/AccionForm.vue
+++ b/src/pages/sistema/AccionForm.vue
@@ -17,6 +17,7 @@ const isEdit = !!id
 const fields = [
   { field: 'nombre', label: 'Nombre', type: 'text' },
   { field: 'descripcion', label: 'Descripción', type: 'textarea', required: false },
+  { field: 'icono', label: 'Ícono', type: 'text' },
 ]
 
 // Configuración del título dinámico

--- a/src/pages/sistema/AccionesPage.vue
+++ b/src/pages/sistema/AccionesPage.vue
@@ -28,7 +28,15 @@ const columns = [
     field: 'nombre',
     sortable: true,
   },
+  
   { name: 'actions', label: 'Acciones', align: 'center' },
+  {
+    name: 'icono',
+    label: 'Ícono',
+    align: 'left',
+    field: 'icono',
+    sortable: false, 
+  },
 ]
 
 const filters = [

--- a/src/pages/sistema/EditarAccion.vue
+++ b/src/pages/sistema/EditarAccion.vue
@@ -12,7 +12,10 @@ const props = defineProps({
   },
 });
 
-const fields = [{ field: "nombre", label: "Nombre", type: "text" }];
+const fields = [
+  { field: "nombre", label: "Nombre", type: "text" },
+  { field: "icono", label: "Ícono", type: "text" }, 
+];
 
 const titulo = {
   title: "Editar acción",

--- a/src/pages/sistema/NuevaAccion.vue
+++ b/src/pages/sistema/NuevaAccion.vue
@@ -8,6 +8,7 @@ import DynamicPage from 'src/components/DynamicPage.vue'
 const fields = [
   { field: 'nombre', label: 'Nombre', type: 'text' },
   { field: 'descripcion', label: 'Descripción', type: 'textarea' },
+  { field: 'icono', label: 'Ícono', type: 'text' },
 ]
 
 const titulo = {

--- a/src/pages/tramite/NuevoDocumentoPage.vue
+++ b/src/pages/tramite/NuevoDocumentoPage.vue
@@ -194,7 +194,7 @@
 
 <script setup>
 import { reactive, onMounted, watch, ref } from 'vue'
-import { Notify } from 'quasar'
+import { Notify, Loading} from 'quasar'
 import { useRouter } from 'vue-router'
 import { api } from 'src/boot/axios'
 import { usePersonaStore } from 'src/stores/persona'
@@ -341,8 +341,13 @@ watch(
 const submitForm = async () => {
   Object.keys(errores).forEach((k) => (errores[k] = false))
   Object.keys(errores_texto).forEach((k) => (errores_texto[k] = ''))
-
+  
   try {
+    Loading.show({
+    message: 'Guardando documento...',
+    spinnerColor: 'white'
+  })
+
     const formData = new FormData()
     formData.append('numero', info.expediente)
     formData.append('estado', 'Abierto')
@@ -399,6 +404,9 @@ const submitForm = async () => {
       type: 'negative',
       message: 'Revisa los errores en el formulario',
     })
+  }
+  finally {
+    Loading.hide()
   }
 }
 </script>


### PR DESCRIPTION
### Descripción
- Agrega el campo **Ícono** en acciones para poder asignar y mostrar un ícono.
- Se agregó un **loading** al guardar acciones para mejorar la experiencia de usuario.
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/10c3b4c5-9120-4036-8385-ce601d3efdfc" />

### Cambios
- Formulario: nuevo campo `icono`.
<img width="723" height="487" alt="image" src="https://github.com/user-attachments/assets/12d6045d-8a33-490e-9bac-0096d21507d2" />

- Tabla: nueva columna `Ícono`.
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/a5855243-99d6-4d89-bd7e-eb627d9cfc98" />

Closes #68 #69 