### PR TITLE
Opciones para escoger oficina destino y destinatario

### DIFF
--- a/src/components/APIEditInline.vue
+++ b/src/components/APIEditInline.vue
@@ -1,264 +1,283 @@
 <template>
-    <div class="cursor-pointer">
-      <div class="text-h6">{{ label }}:</div>
-      <span class="editable" v-if="isCombo && selectedLabel">{{
-        selectedLabel
-      }}</span>
-      <div class="editable" v-else-if="valor">
-        {{ valor }}
-        <q-inner-loading :showing="isLoading" label="Cargando..." />
-      </div>
-      <q-img
-        v-else-if="url && tipo !== 'combo'"
-        loading="lazy"
-        :src="url"
-        alt="Archivo"
-        style="max-width: 150px"
-      />
-      <q-popup-edit v-model="valor" v-slot="scope">
-        <div v-if="isCombo">
-          <q-select
-            emit-value
-            map-options
-            v-model="scope.value"
-            :options="opciones"
-            option-label="label"
-            option-value="value"
-            :label="label"
-            :loading="isLoading"
-          >
-            <template v-slot:after>
-              <q-btn
-                flat
-                dense
-                color="negative"
-                icon="cancel"
-                @click.stop.prevent="scope.cancel"
-              />
-              <q-btn
-                flat
-                dense
-                color="positive"
-                icon="check_circle"
-                @click.stop.prevent="() => saveData(scope)"
-              />
-            </template>
-          </q-select>
-        </div>
-        <div v-else-if="url && tipo !== 'combo'">
-          <q-file
-            v-model="file"
-            @keyup.enter="() => saveData(scope)"
-            outlined
-            dense
-            :loading="isLoading"
-          >
-            <template v-slot:prepend>
-              <q-icon name="attach_file" />
-            </template>
-            <template v-slot:after>
-              <q-btn
-                flat
-                dense
-                color="negative"
-                icon="cancel"
-                @click.stop.prevent="scope.cancel"
-              />
-              <q-btn
-                flat
-                dense
-                color="positive"
-                icon="check_circle"
-                @click.stop.prevent="() => saveData(scope)"
-              />
-            </template>
-          </q-file>
-        </div>
-        <q-input
-          v-else
-          v-model="scope.value"
+  <div class="cursor-pointer">
+    <div class="text-h6">{{ label }}:</div>
+    <span class="editable" v-if="isCombo && selectedLabel">{{ selectedLabel }}</span>
+    <div class="editable" v-else-if="valor">
+      {{ valor }}
+      <q-inner-loading :showing="isLoading" label="Cargando..." />
+    </div>
+    <q-img
+      v-else-if="url && tipo !== 'combo'"
+      loading="lazy"
+      :src="url"
+      alt="Archivo"
+      style="max-width: 150px"
+    />
+
+    <q-popup-edit v-model="valor" v-slot="scope">
+      <!-- APIELECT -->
+
+      <div v-if="props.tipo === 'apiselect'">
+        <APISelect
+          :url="props.apiurl"
+          v-model="valor"
+          field="nombre"
+          label="Selecciona una opción"
+          option-value="nombre"
+          option-label="nombre"
           dense
-          autofocus
-          outlined
-          @keyup.enter="() => saveData(scope)"
+          @update:model-value="onSelectChange"
+        />
+      </div>
+
+      <div v-if="isCombo">
+        <q-select
+          emit-value
+          map-options
+          v-model="scope.value"
+          :options="opciones"
+          option-label="label"
+          option-value="value"
+          :label="label"
           :loading="isLoading"
-          :type="scope.value.length > 50 ? 'textarea' : 'text'"
-          :readonly="isCombo"
         >
           <template v-slot:after>
-            <q-btn
-              flat
-              dense
-              color="negative"
-              icon="cancel"
-              @click.stop.prevent="scope.cancel"
-            />
+            <q-btn flat dense color="negative" icon="cancel" @click.stop.prevent="scope.cancel" />
             <q-btn
               flat
               dense
               color="positive"
               icon="check_circle"
               @click.stop.prevent="() => saveData(scope)"
-              :disable="
-                (scope.validate && !scope.validate(scope.value)) ||
-                scope.initialValue === scope.value
-              "
             />
           </template>
-        </q-input>
-      </q-popup-edit>
-    </div>
-  </template>
-  
-  <script setup>
-  import { ref, computed, onMounted } from "vue";
-  import { api } from "src/boot/axios";
-  import { Notify } from "quasar";
-  
-  const props = defineProps({
-    clave: {
-      type: String,
-      required: true,
-    },
-    label: {
-      type: String,
-      required: true,
-    },
-    tipo: {
-      type: String,
-      default: null,
-    },
-    opciones: {
-      type: Array,
-      default: () => [],
-    },
-  });
-  
-  const valor = ref("");
-  const url = ref(null);
-  const file = ref(null);
-  const isLoading = ref(false);
-  
-  const isCombo = computed(() => props.tipo === "combo");
-  
-  const selectedLabel = computed(() => {
-    const selectedOption = props.opciones.find(
-      (option) => option.value === valor.value
-    );
-    return selectedOption ? selectedOption.label : valor.value;
-  });
-  
-  const fetchData = () => {
-    isLoading.value = true;
-    const urlWithParam = `api/base/opcion/${props.clave}`;
-    api
-      .get(urlWithParam)
-      .then((response) => {
-        valor.value = response.data?.valor || "";
-        url.value = response.data?.url || null;
-        isLoading.value = false;
-      })
-      .catch(() => {
-        isLoading.value = false;
-      });
-  };
-  
-  const saveData = (scope) => {
-    if (url.value && props.tipo !== "combo") {
-      uploadFile(scope);
-    } else {
-      saveTextData(scope);
-    }
-  };
-  
-  const saveTextData = (scope) => {
-    valor.value = scope.value;
-  
-    if (!valor.value || scope.initialValue === valor.value) {
+        </q-select>
+      </div>
+      <div v-else-if="url && tipo !== 'combo'">
+        <q-file
+          v-model="file"
+          @keyup.enter="() => saveData(scope)"
+          outlined
+          dense
+          :loading="isLoading"
+        >
+          <template v-slot:prepend>
+            <q-icon name="attach_file" />
+          </template>
+          <template v-slot:after>
+            <q-btn flat dense color="negative" icon="cancel" @click.stop.prevent="scope.cancel" />
+            <q-btn
+              flat
+              dense
+              color="positive"
+              icon="check_circle"
+              @click.stop.prevent="() => saveData(scope)"
+            />
+          </template>
+        </q-file>
+      </div>
+      <q-input
+        v-else
+        v-model="scope.value"
+        dense
+        autofocus
+        outlined
+        @keyup.enter="() => saveData(scope)"
+        :loading="isLoading"
+        :type="scope.value.length > 50 ? 'textarea' : 'text'"
+        :readonly="isCombo"
+      >
+        <template v-slot:after>
+          <q-btn flat dense color="negative" icon="cancel" @click.stop.prevent="scope.cancel" />
+          <q-btn
+            flat
+            dense
+            color="positive"
+            icon="check_circle"
+            @click.stop.prevent="() => saveData(scope)"
+            :disable="
+              (scope.validate && !scope.validate(scope.value)) || scope.initialValue === scope.value
+            "
+          />
+        </template>
+      </q-input>
+    </q-popup-edit>
+  </div>
+</template>
+
+<script setup>
+import APISelect from 'src/components/APISelect.vue'
+import { ref, computed, onMounted } from 'vue'
+import { api } from 'src/boot/axios'
+import { Notify } from 'quasar'
+
+const props = defineProps({
+  clave: {
+    type: String,
+    required: true,
+  },
+  label: {
+    type: String,
+    required: true,
+  },
+  tipo: {
+    type: String,
+    default: null,
+  },
+  opciones: {
+    type: Array,
+    default: () => [],
+  },
+  apiurl: { type: String },
+})
+
+const valor = ref('')
+const url = ref(null)
+const file = ref(null)
+const isLoading = ref(false)
+
+const isCombo = computed(() => props.tipo === 'combo')
+
+const selectedLabel = computed(() => {
+  const selectedOption = props.opciones.find((option) => option.value === valor.value)
+  return selectedOption ? selectedOption.label : valor.value
+})
+
+// guardar automáticamente el nombre del apiselect
+const onSelectChange = (nuevoValor) => {
+  if (!nuevoValor) return
+  isLoading.value = true
+  api
+    .patch(`api/base/opcion/${props.clave}/`, { valor: nuevoValor })
+    .then(() => {
+      valor.value = nuevoValor
+      isLoading.value = false
       Notify.create({
-        type: "warning",
-        message: "No se realizaron cambios.",
-      });
-      return;
-    }
-  
-    isLoading.value = true;
-    const urlWithParam = `api/base/opcion/${props.clave}/`;
-    api
-      .patch(urlWithParam, { valor: valor.value })
-      .then(() => {
-        isLoading.value = false;
-        scope.set();
-        Notify.create({
-          type: "positive",
-          message: "Datos guardados correctamente.",
-        });
+        type: 'positive',
+        message: 'Opción guardada correctamente.',
       })
-      .catch(() => {
-        isLoading.value = false;
-        Notify.create({
-          type: "negative",
-          message: "Error al guardar los datos.",
-        });
-      });
-  };
-  
-  const uploadFile = (scope) => {
-    if (!file.value) {
+    })
+    .catch(() => {
+      isLoading.value = false
       Notify.create({
-        type: "warning",
-        message: "Por favor, selecciona un archivo para subir.",
-      });
-      return;
-    }
-  
-    const formData = new FormData();
-    formData.append("url", file.value);
-  
-    isLoading.value = true;
-    const urlWithParam = `api/base/opcion/${props.clave}/`;
-    api
-      .patch(urlWithParam, formData, {
-        headers: {
-          "Content-Type": "multipart/form-data",
-        },
+        type: 'negative',
+        message: 'Error al guardar la opción.',
       })
-      .then((response) => {
-        url.value = response.data.url;
-        isLoading.value = false;
-        scope.set();
-        Notify.create({
-          type: "positive",
-          message: "Archivo subido y guardado correctamente.",
-        });
-      })
-      .catch(() => {
-        isLoading.value = false;
-        Notify.create({
-          type: "negative",
-          message: "Error al subir el archivo.",
-        });
-      });
-  };
-  
-  onMounted(() => {
-    fetchData();
-  });
-  </script>
-  
-  <style>
-  .editable {
-    display: inline-block;
-    padding: 0.3rem 0.5rem;
-    border: 1px dashed #ccc;
-    cursor: pointer;
-    overflow-wrap: break-word;
-    inline-size: 100%;
-  
-    &:hover {
-      border-color: #9f9d9d;
-      background-color: rgb(255, 255, 218);
-    }
+    })
+}
+
+const fetchData = () => {
+  isLoading.value = true
+  const urlWithParam = `api/base/opcion/${props.clave}`
+  api
+    .get(urlWithParam)
+    .then((response) => {
+      valor.value = response.data?.valor || ''
+      url.value = response.data?.url || null
+      isLoading.value = false
+    })
+    .catch(() => {
+      isLoading.value = false
+    })
+}
+
+const saveData = (scope) => {
+  if (props.tipo == 'apiselect') {
+    valor.value = scope.value
+  } else if (url.value && props.tipo !== 'combo') {
+    uploadFile(scope)
+  } else {
+    saveTextData(scope)
   }
-  </style>
-  
+}
+
+const saveTextData = (scope) => {
+  valor.value = scope.value
+
+  if (!valor.value || scope.initialValue === valor.value) {
+    Notify.create({
+      type: 'warning',
+      message: 'No se realizaron cambios.',
+    })
+    return
+  }
+
+  isLoading.value = true
+  const urlWithParam = `api/base/opcion/${props.clave}/`
+  api
+    .patch(urlWithParam, { valor: valor.value })
+    .then(() => {
+      isLoading.value = false
+      scope.set()
+      Notify.create({
+        type: 'positive',
+        message: 'Datos guardados correctamente.',
+      })
+    })
+    .catch(() => {
+      isLoading.value = false
+      Notify.create({
+        type: 'negative',
+        message: 'Error al guardar los datos.',
+      })
+    })
+}
+
+const uploadFile = (scope) => {
+  if (!file.value) {
+    Notify.create({
+      type: 'warning',
+      message: 'Por favor, selecciona un archivo para subir.',
+    })
+    return
+  }
+
+  const formData = new FormData()
+  formData.append('url', file.value)
+
+  isLoading.value = true
+  const urlWithParam = `api/base/opcion/${props.clave}/`
+  api
+    .patch(urlWithParam, formData, {
+      headers: {
+        'Content-Type': 'multipart/form-data',
+      },
+    })
+    .then((response) => {
+      url.value = response.data.url
+      isLoading.value = false
+      scope.set()
+      Notify.create({
+        type: 'positive',
+        message: 'Archivo subido y guardado correctamente.',
+      })
+    })
+    .catch(() => {
+      isLoading.value = false
+      Notify.create({
+        type: 'negative',
+        message: 'Error al subir el archivo.',
+      })
+    })
+}
+
+onMounted(() => {
+  fetchData()
+})
+</script>
+
+<style>
+.editable {
+  display: inline-block;
+  padding: 0.3rem 0.5rem;
+  border: 1px dashed #ccc;
+  cursor: pointer;
+  overflow-wrap: break-word;
+  inline-size: 100%;
+
+  &:hover {
+    border-color: #9f9d9d;
+    background-color: rgb(255, 255, 218);
+  }
+}
+</style>

--- a/src/pages/sistema/OpcionPage.vue
+++ b/src/pages/sistema/OpcionPage.vue
@@ -13,6 +13,7 @@
             :label="opcion.label"
             :tipo="opcion.tipo"
             :opciones="opcion.options"
+            :apiurl="opcion.apiurl"
           />
         </div>
       </div>
@@ -42,6 +43,18 @@ const opciones = ref([
       { value: 'oficina', label: 'Por oficina' },
       { value: 'usuario', label: 'Por usuario' },
     ],
+  },
+  {
+    clave: 'oficina_mesa_partes',
+    label: 'Oficina de Mesa de Partes',
+    tipo: 'apiselect',
+    apiurl: '/api/base/oficinas/',
+  },
+  {
+    clave: 'destinatario_mesa_partes',
+    label: 'Destinatario para Mesa de Partes',
+    tipo: 'apiselect',
+    apiurl: '/api/base/cargos/',
   },
 ])
 </script>


### PR DESCRIPTION
# Cambios

Se modificó `APIEditInline` para que ahora soporte `APISelect`, permitiendo cargar opciones dinámicamente desde un endpoint.  

Se añadieron dos nuevas opciones en la configuración:  

- **Oficina de Mesa de Partes:** Selección de la oficina destino mediante `APISelect` conectado a `/api/base/oficinas/`.  
- **Destinatario para Mesa de Partes:** Selección del destinatario dentro de la oficina, mediante `APISelect` conectado a `/api/base/cargos/`.  

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/51593ef3-4242-4adf-abb3-2e8571dd973f" />

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/665e0e63-ec93-4e36-b100-8b0f6327f924" />

Closes #74 