### PR TITLE
Feat/mesa de partes front

### DIFF
--- a/src/pages/sistema/OpcionPage.vue
+++ b/src/pages/sistema/OpcionPage.vue
@@ -43,5 +43,7 @@ const opciones = ref([
       { value: 'usuario', label: 'Por usuario' },
     ],
   },
+  { clave: 'tramite_oficina', label: 'Oficina de Mesa de Partes'},
+  { clave: 'tramite_destinatario', label: 'Destinatario Mesa de Partes'},
 ])
 </script>

--- a/src/pages/tramite/MesaDePartes.vue
+++ b/src/pages/tramite/MesaDePartes.vue
@@ -254,7 +254,6 @@ async function fetchNumeroExpediente() {
 async function fetchTiposDocumento() {
   try {
     const { data } = await api.get('/api/base/tipos-documento-publicos/')
-    // el endpoint devuelve paginado: {count, next, previous, results}
     tiposDocumento.value = data.results || data
     tiposDocumentoOptions.value = data.results || data
     console.log('Tipos documento cargados:', tiposDocumento.value)
@@ -276,7 +275,7 @@ const form = reactive({
   remitente_celular: '',
   tipo_documento: null, // aquí guardamos el ID (number)
   asunto: '',
-  archivos: [] // Array de objetos con estructura: { id, file, descripcion }
+  archivos: [] // Array de objetos 
 })
 
 // computed para mostrar el nombre del tipo seleccionado
@@ -317,7 +316,7 @@ function onRejectedFiles(rejectedEntries) {
   })
 }
 
-// Función para manejar cuando se seleccionan archivos (automáticamente los agrega)
+// Función para manejar cuando se seleccionan archivos 
 function onFilesSelected(files) {
   if (!files || files.length === 0) {
     return
@@ -406,7 +405,6 @@ async function submitForm() {
   try {
     submitting.value = true
     
-    // validación final
     if (!form.tipo_documento || !form.asunto || !form.asunto.trim()) {
       Notify.create({ type: 'negative', message: 'Faltan campos requeridos (tipo y asunto)' })
       return
@@ -428,10 +426,8 @@ async function submitForm() {
     fd.append('remitente_celular', form.remitente_celular.trim())
 
     // Documento: **clave exacta que espera el backend** -> 'documento[tipo]'
-    // pasamos el ID como string (FormData siempre manda strings)
     fd.append('documento[tipo]', String(form.tipo_documento))
     fd.append('documento[asunto]', form.asunto.trim())
-    // NO enviamos documento[fecha_documento] porque dijiste que backend no lo requiere
 
     // Archivos: lista, cada uno con su descripcion
     if (form.archivos && form.archivos.length > 0) {
@@ -441,7 +437,6 @@ async function submitForm() {
       })
     }
 
-    // DEBUG: listar FormData (no mostrará binarios completos en consola)
     for (const pair of fd.entries()) {
       if (pair[1] instanceof File) {
         console.log('FormData =>', pair[0], `[File: ${pair[1].name}, ${pair[1].size} bytes]`)
@@ -450,9 +445,8 @@ async function submitForm() {
       }
     }
 
-    // IMPORTANTE: NO fijar manualmente 'Content-Type' aquí. Deja que axios/browser lo asigne
     const response = await api.post('/api/tramite/mesa-partes/', fd, {
-      timeout: 60000, // 60 segundos para archivos grandes
+      timeout: 10000, // 10 segundos para archivos grandes
       onUploadProgress: (progressEvent) => {
         if (progressEvent.total) {
           const percentCompleted = Math.round((progressEvent.loaded * 100) / progressEvent.total)
@@ -474,7 +468,7 @@ async function submitForm() {
     
   } catch (error) {
     console.error('Error submit:', error)
-    // procesar errores del backend para mostrarlos bonitos
+    // procesar errores del backend para mostrarlos 
     let errorMessage = 'Error al registrar documento'
     
     if (error.code === 'ECONNABORTED') {
@@ -527,7 +521,7 @@ function resetForm() {
     archivos: []
   })
   
-  // Limpiar también la selección temporal
+  // Limpiar  la selección temporal
   selectedFiles.value = []
   fileIdCounter = 0
 }

--- a/src/pages/tramite/MesaDePartes.vue
+++ b/src/pages/tramite/MesaDePartes.vue
@@ -170,7 +170,7 @@
               <q-card-section>
                 <div class="text-h6">Datos del Documento</div>
                 <!-- mostramos el nombre usando computed tipoDocumentoNombre -->
-                <p><b>Tipo:</b> {{ tipoDocumentoNombre }} (ID: {{ form.tipo_documento || '-' }})</p>
+                <p><b>Tipo:</b> {{ tipoDocumentoNombre }}</p>
                 <p><b>Asunto:</b> {{ form.asunto }}</p>
               </q-card-section>
             </q-card>

--- a/src/pages/tramite/MesaDePartes.vue
+++ b/src/pages/tramite/MesaDePartes.vue
@@ -1,0 +1,257 @@
+<template>
+  <q-page padding>
+    <PageTitle title="Mesa de Partes" icon="assignment" />
+
+    <div class="row justify-center q-mt-lg q-mb-md">
+      <q-card flat bordered class="q-pa-md bg-grey-1" style="max-width: 600px; width: 100%;">
+        <div class="row justify-around items-center">
+
+          <div class="row items-center">
+            <span class="text-subtitle1 text-bold q-mr-sm">Fecha :</span>
+            <q-input
+              v-model="fechaActual"
+              outlined
+              dense
+              readonly
+              style="max-width: 150px;"
+              class="bg-grey-2"
+            />
+          </div>
+
+          <div class="row items-center">
+            <span class="text-subtitle1 text-bold q-mr-sm">Nro de Solicitud :</span>
+            <q-input
+              v-model="numeroExpediente"
+              outlined
+              dense
+              readonly
+              style="max-width: 150px;"
+              class="bg-grey-2"
+            />
+          </div>
+        </div>
+      </q-card>
+    </div>
+
+
+
+    <div class="q-pa-md">
+      <q-stepper v-model="step" flat animated header-nav color="primary">
+
+        <!-- Paso 1: Datos del Remitente -->
+        <q-step :name="1" title="Datos del Remitente" icon="person" :done="step > 1">
+          <q-form @submit.prevent="nextStep">
+            <q-input outlined v-model="form.remitente_nombres" label="Nombres" required />
+            <q-input outlined v-model="form.remitente_apellidos" label="Apellidos" required />
+            <q-input outlined v-model="form.remitente_documento" label="Documento de identidad" required />
+            <q-input outlined v-model="form.remitente_email" label="Correo electrónico" type="email" required />
+            <q-input
+              outlined
+              v-model="form.remitente_celular"
+              label="Celular"
+              type="tel"
+              :rules="[val => /^\d{9}$/.test(val) || 'Debe tener 9 dígitos']"
+              required
+            />
+
+            <div class="q-mt-md">
+              <q-btn label="Siguiente" type="submit" color="primary" />
+            </div>
+          </q-form>
+        </q-step>
+
+        <!-- Paso 2: Datos del Documento -->
+        <q-step :name="2" title="Datos del Documento" icon="description" :done="step > 2">
+          <q-form @submit.prevent="nextStep">
+            <APISelect
+              v-model="form.tipo_documento"
+              label="Tipo de documento"
+              url="/api/base/tipos-documento/"
+              field="nombre"
+              option-value="id"
+              option-label="nombre"
+              dense
+              required
+              :emit-value="false"
+              :map-options="true"
+            />
+            <q-input outlined v-model="form.asunto" label="Asunto" type="textarea" autogrow required />
+
+            <div class="q-mt-md flex justify-between">
+              <q-btn flat label="Atrás" @click="prevStep" />
+              <q-btn label="Siguiente" type="submit" color="primary" />
+            </div>
+          </q-form>
+        </q-step>
+
+        <!-- Paso 3: Adjuntar archivos -->
+        <q-step :name="3" title="Archivos" icon="attach_file" :done="step > 3">
+          <q-form @submit.prevent="nextStep">
+            <q-file
+              v-model="form.archivos"
+              label="Adjuntar archivos"
+              multiple
+              outlined
+              use-chips
+              accept=".pdf,.jpg,.png,.doc,.docx"
+              counter
+            />
+            <div v-for="(f, i) in form.archivos" :key="i" class="q-mt-sm">
+              <div class="text-caption">{{ f.name }} ({{ (f.size / 1024).toFixed(1) }} KB)</div>
+              <q-input dense v-model="form.archivosDescripciones[i]" label="Descripción (opcional)" />
+            </div>
+
+            <div class="q-mt-md flex justify-between">
+              <q-btn flat label="Atrás" @click="prevStep" />
+              <q-btn label="Siguiente" type="submit" color="primary" />
+            </div>
+          </q-form>
+        </q-step>
+
+        <!-- Paso 4: Confirmación -->
+        <q-step :name="4" title="Confirmación" icon="check_circle">
+          <div class="q-gutter-md">
+            <q-card flat bordered>
+              <q-card-section>
+                <div class="text-h6">Datos del Remitente</div>
+                <p><b>Nombres:</b> {{ form.remitente_nombres }}</p>
+                <p><b>Apellidos:</b> {{ form.remitente_apellidos }}</p>
+                <p><b>DNI:</b> {{ form.remitente_documento }}</p>
+                <p><b>Correo:</b> {{ form.remitente_email }}</p>
+                <p><b>Celular:</b> {{ form.remitente_celular }}</p>
+              </q-card-section>
+            </q-card>
+
+            <q-card flat bordered>
+              <q-card-section>
+                <div class="text-h6">Datos del Documento</div>
+                <p><b>Tipo:</b> {{ form.tipo_documento?.nombre }} (ID: {{ form.tipo_documento?.id }})</p>
+                <p><b>Asunto:</b> {{ form.asunto }}</p>
+              </q-card-section>
+            </q-card>
+
+            <q-card flat bordered>
+              <q-card-section>
+                <div class="text-h6">Archivos</div>
+                <div v-if="form.archivos.length">
+                  <ul>
+                    <li v-for="(file, i) in form.archivos" :key="i">
+                      {{ file.name }} ({{ (file.size/1024).toFixed(1) }} KB) - 
+                      {{ form.archivosDescripciones[i] || 'Sin descripción' }}
+                    </li>
+                  </ul>
+                </div>
+                <div v-else>
+                  <p>No se adjuntaron archivos</p>
+                </div>
+              </q-card-section>
+            </q-card>
+          </div>
+
+          <div class="q-mt-md flex justify-between">
+            <q-btn flat label="Atrás" @click="prevStep" />
+            <q-btn label="Confirmar y Enviar" color="positive" @click="submitForm" />
+          </div>
+        </q-step>
+
+      </q-stepper>
+    </div>
+  </q-page>
+</template>
+
+<script setup>
+import { ref, reactive, onMounted } from 'vue'
+import { Notify } from 'quasar'
+import { api } from 'src/boot/axios'
+import PageTitle from 'src/components/PageTitle.vue'
+import APISelect from 'src/components/APISelect.vue'
+
+const step = ref(1)
+
+const fechaActual = ref(new Date().toISOString().split('T')[0])
+
+const numeroExpediente = ref('Cargando...')
+
+async function fetchNumeroExpediente() {
+  try {
+    const { data } = await api.get('/api/tramite/expedientes/next-number/')
+    numeroExpediente.value = data.next_number || data // depende de la respuesta de tu API
+  } catch (error) {
+    console.error(error)
+    numeroExpediente.value = 'Error al cargar'
+  }
+}
+
+onMounted(() => {
+  fetchNumeroExpediente()
+})
+
+const form = reactive({
+  remitente_nombres: '',
+  remitente_apellidos: '',
+  remitente_documento: '',
+  remitente_email: '',
+  remitente_celular: '',
+  tipo_documento: null,
+  asunto: '',
+  archivos: [],
+  archivosDescripciones: []
+})
+
+function nextStep() {
+  step.value++
+}
+function prevStep() {
+  step.value--
+}
+
+async function submitForm() {
+  try {
+    const fd = new FormData()
+
+    // Remitente
+    fd.append('remitente_nombres', form.remitente_nombres)
+    fd.append('remitente_apellidos', form.remitente_apellidos)
+    fd.append('remitente_documento', form.remitente_documento)
+    fd.append('remitente_email', form.remitente_email)
+    fd.append('remitente_celular', form.remitente_celular)
+
+    // Documento
+    fd.append('documento[tipo_documento]', form.tipo_documento?.id || '')
+    fd.append('documento[asunto]', form.asunto)
+    fd.append('documento[fecha_documento]', form.fecha_documento)
+
+    // Archivos
+    form.archivos.forEach((file, index) => {
+      fd.append(`documento[archivos][${index}][archivo]`, file)
+      fd.append(`documento[archivos][${index}][descripcion]`, form.archivosDescripciones[index] || '')
+    })
+
+    await api.post('/api/tramite/mesa-partes/', fd, {
+      headers: { 'Content-Type': 'multipart/form-data' }
+    })
+
+    Notify.create({ type: 'positive', message: 'Documento registrado correctamente' })
+    resetForm()
+    step.value = 1
+
+    fetchNumeroExpediente()
+  } catch (error) {
+    console.error(error)
+    Notify.create({ type: 'negative', message: 'Error al registrar documento' })
+  }
+}
+
+function resetForm() {
+  form.remitente_nombres = ''
+  form.remitente_apellidos = ''
+  form.remitente_documento = ''
+  form.remitente_email = ''
+  form.remitente_celular = ''
+  form.tipo_documento = null
+  form.fecha_documento = ''
+  form.asunto = ''
+  form.archivos = []
+  form.archivosDescripciones = []
+}
+</script>

--- a/src/router/routes.js
+++ b/src/router/routes.js
@@ -77,6 +77,18 @@ const routes = [
     ],
     meta: { requiresAuth: true },
   },
+
+  {
+    path: '/mesa-de-partes',
+    component: () => import('layouts/MainLayout.vue'),
+    children: [
+      {
+        path: '',
+        component: () => import('src/pages/tramite/MesaDePartes.vue')
+      }
+    ]
+  },
+  
   {
     path: '/login',
     component: () => import('layouts/AuthLayout.vue'),


### PR DESCRIPTION
### Implementación de página pública con QStepper para Mesa de Partes #72

**Descripción:**
Este PR implementa la nueva página pública /mesa-de-partes utilizando Quasar QStepper para permitir que usuarios externos registren documentos en la Mesa de Partes sin autenticación.

**Cambios realizados:**
Creación de la página` src/pages/tramite/MesaDePartesPage.vue`
Implementación de un formulario multipaso:
**Paso 1**: Datos del remitente
**Paso 2**: Datos del documento (con selección de tipo desde endpoint público)
**Paso 3**: Subida de múltiples archivos con validación (tamaño, tipo, límite de 10 archivos, descripción opcional)
**Paso 4:** Confirmación de datos antes del envío

Integración con:
`/api/tramite/expedientes/next-number/` para mostrar el número de expediente
`/api/base/tipos-documento-publicos/` para listar tipos de documento
`/api/tramite/mesa-partes/ `para envío final vía multipart/form-da

**Funcionamiento:**
<img width="1769" height="759" alt="image" src="https://github.com/user-attachments/assets/8cf90713-2f54-43b0-acf4-66eb2343946c" />
<img width="1799" height="570" alt="image" src="https://github.com/user-attachments/assets/902432f5-3a4e-4693-8781-0bcf12bc2502" />
<img width="1799" height="870" alt="image" src="https://github.com/user-attachments/assets/ebd133e3-60b6-4fee-8156-867e8e6b2d26" />
<img width="1799" height="939" alt="image" src="https://github.com/user-attachments/assets/8e92b9d9-510a-4f7c-ae55-e6f2108b87a1" />
<img width="1799" height="408" alt="image" src="https://github.com/user-attachments/assets/14b70c43-8f1d-4287-a6a9-f1396c61190c" />
