### PR TITLE
feat/seguimiento de expedientes front

### DIFF
--- a/src/pages/tramite/NuevoDocumentoPage.vue
+++ b/src/pages/tramite/NuevoDocumentoPage.vue
@@ -352,9 +352,10 @@ const submitForm = async () => {
     formData.append('documento[tipo]', info.tipo_documento?.id || info.tipo_documento || '')
     formData.append('documento[remitente]', persona.value.id)
     formData.append('documento[numero]', info.numero)
+    debugger
     formData.append(
       'documento[asignacion_cargo]',
-      persona.value.asignaciones_cargo?.find((a) => a.oficina === info.oficina?.value)?.id || '',
+      persona.value.asignaciones_cargo?.find((a) => a.oficina_nombre === info.oficina)?.id || '',
     )
     formData.append('documento[asunto]', info.asunto)
     formData.append('documento[resumen]', '')

--- a/src/pages/tramite/SeguimientoExpedientePage.vue
+++ b/src/pages/tramite/SeguimientoExpedientePage.vue
@@ -1,0 +1,93 @@
+<template>
+  <q-page class="q-pa-md">
+    <div class="row items-center q-mb-md">
+      <div class="col">
+        <div class="text-h6">Seguimiento del expediente {{ numero }}</div>
+        <div class="text-caption text-grey-7" v-if="expediente?.numero">
+          N° {{ expediente.numero }}
+        </div>
+      </div>
+      <div class="col-auto">
+        <q-btn dense flat icon="refresh" :loading="loading" @click="fetchData" />
+      </div>
+    </div>
+
+    <q-card flat bordered>
+      <q-card-section>
+        <q-timeline color="primary">
+          <q-timeline-entry
+            v-for="(ev, idx) in events"
+            :key="idx"
+            :title="ev.label"
+            :subtitle="formatDate(ev.ts)"
+            :icon="iconFor(ev.kind)"
+          >
+            <div class="text-caption">
+              <div v-if="ev.doc_id" class="row items-center no-wrap">
+                <div><b>Documento:</b> {{ ev.doc_tipo }} {{ ev.doc_numero }}</div>
+                <q-btn
+                  dense
+                  flat
+                  round
+                  size="sm"
+                  icon="visibility"
+                  class="q-ml-sm"
+                  @click="goToDocumento(ev.doc_id)"
+                />
+              </div>
+
+              <div v-if="ev.doc_asunto"><b>Asunto:</b> {{ ev.doc_asunto }}</div>
+              <div v-if="ev.destino_id"><b>Destino:</b> {{ ev.destino_oficina }}</div>
+              <div v-if="ev.estado"><b>Estado:</b> {{ ev.estado_nombre }}</div>
+            </div>
+          </q-timeline-entry>
+        </q-timeline>
+      </q-card-section>
+    </q-card>
+  </q-page>
+</template>
+
+<script setup>
+import { onMounted, ref, computed } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+import { api } from 'boot/axios'
+
+const route = useRoute()
+const router = useRouter()
+const numero = computed(() => route.params.numero)
+
+const loading = ref(false)
+const expediente = ref(null)
+const events = ref([])
+
+function formatDate(iso) {
+  try {
+    return new Date(iso).toLocaleString()
+  } catch {
+    return iso
+  }
+}
+function iconFor(kind) {
+  if (kind === 'movimiento') return 'swap_horiz'
+  if (kind === 'destino') return 'send'
+  if (kind === 'estado') return 'flag'
+  return 'event'
+}
+
+async function fetchData() {
+  loading.value = true
+  try {
+    const { data } = await api.get(`/api/tramite/expedientes/${numero.value}/seguimiento/`)
+    expediente.value = data.expediente
+    events.value = (data.events || []).slice().sort((a, b) => a.ts.localeCompare(b.ts))
+  } finally {
+    loading.value = false
+  }
+}
+
+function goToDocumento(id) {
+  router.push(`/documento/${id}`)
+}
+
+onMounted(fetchData)
+</script>

--- a/src/router/routes.js
+++ b/src/router/routes.js
@@ -79,6 +79,11 @@ const routes = [
         component: () => import('src/pages/tramite/ResponderDocumentoPage.vue'),
         props: true,
       },
+      {
+        path: 'expediente/:numero/seguimiento',
+        component: () => import('src/pages/tramite/SeguimientoExpedientePage.vue'),
+        props: true,
+      },
     ],
     meta: { requiresAuth: true },
   },


### PR DESCRIPTION
### **Descripción**
Se añadió la página para ver el seguimiento de un expediente.
### **Cambios Técnicos**
Se creó un nuevo componente `src/pages/tramite/SeguimientoExpedientePage.vue` para poder mostrar el seguimiento del expediente, el cual contiene 3 tipos de instancias: _destino_, _estado_ y _movimiento_.
Estas tres instancias están compuestas por varios campos, entre los cuales tenemos:
- `Documento`: Compuesto por el tipo de documento más su número de documento, para que el usuario no pueda identificarlo más facilmente. Aparece en _destino_, _estado_ y _movimiento_.
- `Asunto`: El asunto del documento. Aparece en _destino_, _estado_ y _movimiento_.
- `Destino`: La oficina destino del documento. Aparece en  _destino_ y _estado_.
- `Estado`: El estado en el que se encuentra el documento. Aparece en _estado_.
Además, se añadió un botón al costado del campo `Documento` que permite ver el documento en cuestión.
### **Capturas de Pantalla**
<img width="1853" height="978" alt="image" src="https://github.com/user-attachments/assets/f99b8c3c-ed57-44c9-bd01-9dba3219dfb7" />
<img width="1853" height="682" alt="image" src="https://github.com/user-attachments/assets/2bd7068b-715d-4bc8-97f6-bf0b136adb9b" />

### **Issue Relacionado**
#79 