### PR TITLE
Feat/mesa partes formulario añadir campos

### DIFF
--- a/src/pages/sistema/OpcionPage.vue
+++ b/src/pages/sistema/OpcionPage.vue
@@ -44,17 +44,8 @@ const opciones = ref([
       { value: 'usuario', label: 'Por usuario' },
     ],
   },
-  {
-    clave: 'oficina_mesa_partes',
-    label: 'Oficina de Mesa de Partes',
-    tipo: 'apiselect',
-    apiurl: '/api/base/oficinas/',
-  },
-  {
-    clave: 'destinatario_mesa_partes',
-    label: 'Destinatario para Mesa de Partes',
-    tipo: 'apiselect',
-    apiurl: '/api/base/cargos/',
-  },
+  { clave: 'tramite_oficina', label: 'Oficina de Mesa de Partes'},
+  { clave: 'tramite_destinatario', label: 'Destinatario Mesa de Partes'},
+
 ])
 </script>

--- a/src/pages/tramite/BandejaEntrada.vue
+++ b/src/pages/tramite/BandejaEntrada.vue
@@ -101,6 +101,16 @@ const table = computed(() => ({
       color: 'primary',
       action: (row) => {
         console.log('Ver documento', row)
+        router.push(`/documento/${row.documento_id}`)
+      },
+    },
+    {
+      label: 'Responder',
+      icon: 'reply',
+      color: 'secondary',
+      action: (row) => {
+        console.log('Responder documento', row)
+        router.push(`/documento/responder/${row.documento_id}`)
       },
     },
   ],

--- a/src/pages/tramite/MesaDePartes.vue
+++ b/src/pages/tramite/MesaDePartes.vue
@@ -34,221 +34,193 @@
     </div>
 
     <div class="q-pa-md">
-      <q-stepper v-model="step" flat animated header-nav color="primary">
+      <div style="max-width: 1000px; margin: 0 auto;">
 
-        <!-- Paso 1: Datos del Remitente -->
-        <q-step :name="1" title="Datos del Remitente" icon="person" :done="step > 1">
-          <q-form @submit.prevent="nextStep">
-            
-            <q-select
-              v-model="form.remitente_tipo_persona"
-              :options="tiposPersonaOptions"
-              option-value="value"
-              option-label="label"
-              emit-value
-              map-options
-              outlined
-              label="Tipo de Persona"
-              dense
-              required
-              class="q-mb-md"
-            />
+        <q-stepper v-model="step" flat animated header-nav color="primary">
 
-            <q-select
-              v-model="form.remitente_tipo_doc"
-              :options="tiposDocOptions"
-              option-value="value"
-              option-label="label"
-              emit-value
-              map-options
-              outlined
-              label="Tipo de Documento"
-              dense
-              required
-              class="q-mb-md"
-            />
+          <!-- Paso 1: Datos del Remitente -->
+          <q-step :name="1" title="Datos del Remitente" icon="person" :done="step > 1">
+            <q-form @submit.prevent="nextStep" class="q-gutter-md">
+              <q-input outlined v-model="form.remitente_nombres" label="Nombres" required />
+              <q-input outlined v-model="form.remitente_apellidos" label="Apellidos" required />
+              <q-input outlined v-model="form.remitente_documento" label="Documento de identidad" required />
+              <q-input outlined v-model="form.remitente_email" label="Correo electrónico" type="email" required />
+              <q-input
+                outlined
+                v-model="form.remitente_celular"
+                label="Celular"
+                type="tel"
+                :rules="[val => /^\d{9}$/.test(val) || 'Debe tener 9 dígitos']"
+                required
+              />
 
-            <q-input outlined v-model="form.remitente_nombres" label="Nombres" required class="q-mb-md" />
-            <q-input outlined v-model="form.remitente_apellidos" label="Apellidos" required class="q-mb-md" />
-            <q-input outlined v-model="form.remitente_documento" label="Número de documento" required class="q-mb-md" />
-            <q-input outlined v-model="form.remitente_email" label="Correo electrónico" type="email" required class="q-mb-md" />
-            <q-input
-              outlined
-              v-model="form.remitente_celular"
-              label="Celular"
-              type="tel"
-              :rules="[val => /^\d{9}$/.test(val) || 'Debe tener 9 dígitos']"
-              required
-              class="q-mb-md"
-            />
+              <div class="q-mt-md">
+                <q-btn label="Siguiente" type="submit" color="primary" />
+              </div>
+            </q-form>
+          </q-step>
 
-            <div class="q-mt-md">
-              <q-btn label="Siguiente" type="submit" color="primary" />
-            </div>
-          </q-form>
-        </q-step>
-        <!-- Paso 2: Datos del Documento -->
-        <q-step :name="2" title="Datos del Documento" icon="description" :done="step > 2">
-          <q-form @submit.prevent="nextStep">
-            <!-- q-select: emit-value hace que v-model guarde SOLO el id (valor numérico). -->
-            <q-select
-              v-model="form.tipo_documento"
-              :options="tiposDocumentoOptions"
-              option-value="id"
-              option-label="nombre"
-              emit-value
-              map-options
-              outlined
-              label="Tipo de documento"
-              dense
-              required
-            />
-            <q-input outlined v-model="form.asunto" label="Asunto" type="textarea" autogrow required />
+          <!-- Paso 2: Datos del Documento -->
+          <q-step :name="2" title="Datos del Documento" icon="description" :done="step > 2">
+            <q-form @submit.prevent="nextStep" class="q-gutter-md">
+              <!-- q-select: emit-value hace que v-model guarde SOLO el id (valor numérico). -->
+              <q-select
+                v-model="form.tipo_documento"
+                :options="tiposDocumentoOptions"
+                option-value="id"
+                option-label="nombre"
+                emit-value
+                map-options
+                outlined
+                label="Tipo de documento"
+                dense
+                required
+              />
+              <q-input outlined v-model="form.asunto" label="Asunto" type="textarea" autogrow required />
 
-            <div class="q-mt-md flex justify-between">
-              <q-btn flat label="Atrás" @click="prevStep" />
-              <q-btn label="Siguiente" type="submit" color="primary" />
-            </div>
-          </q-form>
-        </q-step>
+              <div class="q-mt-md flex justify-between">
+                <q-btn flat label="Atrás" @click="prevStep" />
+                <q-btn label="Siguiente" type="submit" color="primary" />
+              </div>
+            </q-form>
+          </q-step>
 
-        <!-- Paso 3: Adjuntar archivos -->
-        <q-step :name="3" title="Archivos" icon="attach_file" :done="step > 3">
-          <q-form @submit.prevent="nextStep">
-            <!-- File uploader para múltiples archivos -->
-            <q-file
-              v-model="selectedFiles"
-              label="Seleccionar archivos"
-              multiple
-              outlined
-              use-chips
-              accept=".pdf,.jpg,.jpeg,.png,.doc,.docx,.txt,.xlsx,.xls"
-              counter
-              max-files="10"
-              max-file-size="10485760"
-              @rejected="onRejectedFiles"
-              @update:model-value="onFilesSelected"
-            >
-              <template v-slot:prepend>
-                <q-icon name="attach_file" />
-              </template>
-            </q-file>
+          <!-- Paso 3: Adjuntar archivos -->
+          <q-step :name="3" title="Archivos" icon="attach_file" :done="step > 3">
+            <q-form @submit.prevent="nextStep">
+              <!-- File uploader para múltiples archivos -->
+              <q-file
+                v-model="selectedFiles"
+                label="Seleccionar archivos"
+                multiple
+                outlined
+                use-chips
+                accept=".pdf,.jpg,.jpeg,.png,.doc,.docx,.txt,.xlsx,.xls"
+                counter
+                max-files="10"
+                max-file-size="10485760"
+                @rejected="onRejectedFiles"
+                @update:model-value="onFilesSelected"
+              >
+                <template v-slot:prepend>
+                  <q-icon name="attach_file" />
+                </template>
+              </q-file>
 
-            <!-- Lista de archivos agregados -->
-            <div v-if="form.archivos.length > 0" class="q-mt-lg">
-              <div class="text-subtitle1 q-mb-md">Archivos agregados:</div>
-              <q-card v-for="(archivo, index) in form.archivos" :key="archivo.id" class="q-mb-sm">
-                <q-card-section class="q-pa-sm">
-                  <div class="row items-center">
-                    <q-icon name="description" class="q-mr-sm" />
-                    <div class="col">
-                      <div class="text-body2">{{ archivo.file.name }}</div>
-                      <div class="text-caption text-grey-6">
-                        {{ formatFileSize(archivo.file.size) }} - {{ archivo.file.type || 'Tipo desconocido' }}
+              <!-- Lista de archivos agregados -->
+              <div v-if="form.archivos.length > 0" class="q-mt-lg">
+                <div class="text-subtitle1 q-mb-md">Archivos agregados:</div>
+                <q-card v-for="(archivo, index) in form.archivos" :key="archivo.id" class="q-mb-sm">
+                  <q-card-section class="q-pa-sm">
+                    <div class="row items-center">
+                      <q-icon name="description" class="q-mr-sm" />
+                      <div class="col">
+                        <div class="text-body2">{{ archivo.file.name }}</div>
+                        <div class="text-caption text-grey-6">
+                          {{ formatFileSize(archivo.file.size) }} - {{ archivo.file.type || 'Tipo desconocido' }}
+                        </div>
                       </div>
+                      <q-btn 
+                        flat 
+                        round 
+                        color="negative" 
+                        icon="delete" 
+                        size="sm"
+                        @click="removeFile(index)"
+                      />
                     </div>
-                    <q-btn 
-                      flat 
-                      round 
-                      color="negative" 
-                      icon="delete" 
-                      size="sm"
-                      @click="removeFile(index)"
+                    <q-input 
+                      v-model="archivo.descripcion" 
+                      label="Descripción del archivo (opcional)" 
+                      dense
+                      outlined
+                      class="q-mt-sm"
                     />
+                  </q-card-section>
+                </q-card>
+              </div>
+
+              <!-- Información sobre límites -->
+              <div class="q-mt-md text-caption text-grey-6">
+                <div>• Máximo 10 archivos</div>
+                <div>• Tamaño máximo por archivo: 10 MB</div>
+                <div>• Formatos permitidos: PDF, JPG, PNG, DOC, DOCX, TXT, XLS, XLSX</div>
+              </div>
+
+              <div class="q-mt-md flex justify-between">
+                <q-btn flat label="Atrás" @click="prevStep" />
+                <q-btn label="Siguiente" type="submit" color="primary" />
+              </div>
+            </q-form>
+          </q-step>
+
+          <!-- Paso 4: Confirmación -->
+          <q-step :name="4" title="Confirmación" icon="check_circle">
+            <div class="q-gutter-md">
+              <q-card flat bordered>
+                <q-card-section>
+                  <div class="text-h6">Datos del Remitente</div>
+                  <p><b>Nombres:</b> {{ form.remitente_nombres }}</p>
+                  <p><b>Apellidos:</b> {{ form.remitente_apellidos }}</p>
+                  <p><b>DNI:</b> {{ form.remitente_documento }}</p>
+                  <p><b>Correo:</b> {{ form.remitente_email }}</p>
+                  <p><b>Celular:</b> {{ form.remitente_celular }}</p>
+                </q-card-section>
+              </q-card>
+
+              <q-card flat bordered>
+                <q-card-section>
+                  <div class="text-h6">Datos del Documento</div>
+                  <!-- mostramos el nombre usando computed tipoDocumentoNombre -->
+                  <p><b>Tipo:</b> {{ tipoDocumentoNombre }}</p>
+                  <p><b>Asunto:</b> {{ form.asunto }}</p>
+                </q-card-section>
+              </q-card>
+
+              <q-card flat bordered>
+                <q-card-section>
+                  <div class="text-h6">Archivos ({{ form.archivos.length }})</div>
+                  <div v-if="form.archivos.length > 0">
+                    <div v-for="archivo in form.archivos" :key="archivo.id" class="q-mb-sm">
+                      <q-card flat bordered class="bg-grey-1">
+                        <q-card-section class="q-pa-sm">
+                          <div class="row items-center">
+                            <q-icon name="description" class="q-mr-sm text-primary" />
+                            <div class="col">
+                              <div class="text-body2">{{ archivo.file.name }}</div>
+                              <div class="text-caption text-grey-6">
+                              </div>
+                              <div v-if="archivo.descripcion" class="text-caption q-mt-xs">
+                                <strong>Descripción:</strong> {{ archivo.descripcion }}
+                              </div>
+                            </div>
+                          </div>
+                        </q-card-section>
+                      </q-card>
+                    </div>
                   </div>
-                  <q-input 
-                    v-model="archivo.descripcion" 
-                    label="Descripción del archivo (opcional)" 
-                    dense
-                    outlined
-                    class="q-mt-sm"
-                  />
+                  <div v-else class="text-grey-6">
+                    <q-icon name="info" class="q-mr-sm" />
+                    No se adjuntaron archivos
+                  </div>
                 </q-card-section>
               </q-card>
             </div>
 
-            <!-- Información sobre límites -->
-            <div class="q-mt-md text-caption text-grey-6">
-              <div>• Máximo 10 archivos</div>
-              <div>• Tamaño máximo por archivo: 10 MB</div>
-              <div>• Formatos permitidos: PDF, JPG, PNG, DOC, DOCX, TXT, XLS, XLSX</div>
-            </div>
-
             <div class="q-mt-md flex justify-between">
               <q-btn flat label="Atrás" @click="prevStep" />
-              <q-btn label="Siguiente" type="submit" color="primary" />
+              <q-btn 
+                label="Confirmar y Enviar" 
+                color="positive" 
+                @click="submitForm"
+                :loading="submitting"
+                :disable="submitting"
+              />
             </div>
-          </q-form>
-        </q-step>
+          </q-step>
 
-        <!-- Paso 4: Confirmación -->
-        <q-step :name="4" title="Confirmación" icon="check_circle">
-          <div class="q-gutter-md">
-            <q-card flat bordered>
-              <q-card-section>
-                <div class="text-h6">Datos del Remitente</div>
-                <p><b>Tipo de Persona:</b> {{ tipoPersonaLabel }}</p>
-                <p><b>Tipo de Documento:</b> {{ tipoDocLabel }}</p>
-                <p><b>Nombres:</b> {{ form.remitente_nombres }}</p>
-                <p><b>Apellidos:</b> {{ form.remitente_apellidos }}</p>
-                <p><b>DNI:</b> {{ form.remitente_documento }}</p>
-                <p><b>Correo:</b> {{ form.remitente_email }}</p>
-                <p><b>Celular:</b> {{ form.remitente_celular }}</p>
-              </q-card-section>
-            </q-card>
-
-            <q-card flat bordered>
-              <q-card-section>
-                <div class="text-h6">Datos del Documento</div>
-                <!-- mostramos el nombre usando computed tipoDocumentoNombre -->
-                <p><b>Tipo:</b> {{ tipoDocumentoNombre }}</p>
-                <p><b>Asunto:</b> {{ form.asunto }}</p>
-              </q-card-section>
-            </q-card>
-
-            <q-card flat bordered>
-              <q-card-section>
-                <div class="text-h6">Archivos ({{ form.archivos.length }})</div>
-                <div v-if="form.archivos.length > 0">
-                  <div v-for="archivo in form.archivos" :key="archivo.id" class="q-mb-sm">
-                    <q-card flat bordered class="bg-grey-1">
-                      <q-card-section class="q-pa-sm">
-                        <div class="row items-center">
-                          <q-icon name="description" class="q-mr-sm text-primary" />
-                          <div class="col">
-                            <div class="text-body2">{{ archivo.file.name }}</div>
-                            <div class="text-caption text-grey-6">
-                            </div>
-                            <div v-if="archivo.descripcion" class="text-caption q-mt-xs">
-                              <strong>Descripción:</strong> {{ archivo.descripcion }}
-                            </div>
-                          </div>
-                        </div>
-                      </q-card-section>
-                    </q-card>
-                  </div>
-                </div>
-                <div v-else class="text-grey-6">
-                  <q-icon name="info" class="q-mr-sm" />
-                  No se adjuntaron archivos
-                </div>
-              </q-card-section>
-            </q-card>
-          </div>
-
-          <div class="q-mt-md flex justify-between">
-            <q-btn flat label="Atrás" @click="prevStep" />
-            <q-btn 
-              label="Confirmar y Enviar" 
-              color="positive" 
-              @click="submitForm"
-              :loading="submitting"
-              :disable="submitting"
-            />
-          </div>
-        </q-step>
-
-      </q-stepper>
+        </q-stepper>
+       </div>
     </div>
   </q-page>
 </template>
@@ -268,20 +240,6 @@ const selectedFiles = ref([])
 // tipos
 const tiposDocumento = ref([])
 const tiposDocumentoOptions = ref([])
-
-const tiposPersonaOptions = ref([
-  { value: '1', label: 'Persona natural' },
-  { value: '2', label: 'Persona jurídica' }
-])
-
-const tiposDocOptions = ref([
-  { value: '1', label: 'DNI' },
-  { value: '2', label: 'RUC' },
-  { value: '3', label: 'Carnet de extranjería' },
-  { value: '4', label: 'Pasaporte' },
-  { value: '5', label: 'Sin documento (Código temporal)' },
-  { value: '6', label: 'Permiso temporal del permanencia' }
-])
 
 // Contador para IDs únicos de archivos
 let fileIdCounter = 0
@@ -318,11 +276,9 @@ const form = reactive({
   remitente_documento: '',
   remitente_email: '',
   remitente_celular: '',
-  remitente_tipo_persona: '1', //  default Persona natural
-  remitente_tipo_doc: '1',     // default DNI
-  tipo_documento: null,       // aquí guardamos el ID 
+  tipo_documento: null, // aquí guardamos el ID (number)
   asunto: '',
-  archivos: [] 
+  archivos: [] // Array de objetos 
 })
 
 // computed para mostrar el nombre del tipo seleccionado
@@ -330,16 +286,6 @@ const tipoDocumentoNombre = computed(() => {
   if (!form.tipo_documento || !tiposDocumento.value.length) return 'No seleccionado'
   const t = tiposDocumento.value.find(x => x.id === form.tipo_documento)
   return t ? t.nombre : 'No encontrado'
-})
-
-const tipoPersonaLabel = computed(() => {
-  const tipo = tiposPersonaOptions.value.find(x => x.value === form.remitente_tipo_persona)
-  return tipo ? tipo.label : 'No seleccionado'
-})
-
-const tipoDocLabel = computed(() => {
-  const tipo = tiposDocOptions.value.find(x => x.value === form.remitente_tipo_doc)
-  return tipo ? tipo.label : 'No seleccionado'
 })
 
 // Función para formatear el tamaño del archivo
@@ -481,9 +427,6 @@ async function submitForm() {
     fd.append('remitente_documento', form.remitente_documento.trim())
     fd.append('remitente_email', form.remitente_email.trim())
     fd.append('remitente_celular', form.remitente_celular.trim())
-    fd.append('remitente_tipo_persona', form.remitente_tipo_persona) 
-    fd.append('remitente_tipo_doc', form.remitente_tipo_doc)         
-
 
     // Documento: **clave exacta que espera el backend** -> 'documento[tipo]'
     fd.append('documento[tipo]', String(form.tipo_documento))
@@ -558,7 +501,7 @@ async function submitForm() {
     Notify.create({ 
       type: 'negative', 
       message: errorMessage, 
-      timeout: 8000,
+      timeout: 30000,
       actions: [{
         label: 'Cerrar',
         color: 'white'
@@ -576,9 +519,6 @@ function resetForm() {
     remitente_documento: '',
     remitente_email: '',
     remitente_celular: '',
-    remitente_tipo_persona: '1', // default
-    remitente_tipo_doc: '1',     //  default
-
     tipo_documento: null,
     asunto: '',
     archivos: []

--- a/src/pages/tramite/MesaDePartes.vue
+++ b/src/pages/tramite/MesaDePartes.vue
@@ -1,0 +1,528 @@
+<template>
+  <q-page padding>
+    <PageTitle title="Mesa de Partes" icon="assignment" />
+
+    <div class="row justify-center q-mt-lg q-mb-md">
+      <q-card flat bordered class="q-pa-md bg-grey-1" style="max-width: 600px; width: 100%;">
+        <div class="row justify-around items-center">
+
+          <div class="row items-center">
+            <span class="text-subtitle1 text-bold q-mr-sm">Fecha :</span>
+            <q-input
+              v-model="fechaActual"
+              outlined
+              dense
+              readonly
+              style="max-width: 150px;"
+              class="bg-grey-2"
+            />
+          </div>
+
+          <div class="row items-center">
+            <span class="text-subtitle1 text-bold q-mr-sm">Nro de Solicitud :</span>
+            <q-input
+              v-model="numeroExpediente"
+              outlined
+              dense
+              readonly
+              style="max-width: 150px;"
+              class="bg-grey-2"
+            />
+          </div>
+        </div>
+      </q-card>
+    </div>
+
+    <div class="q-pa-md">
+      <q-stepper v-model="step" flat animated header-nav color="primary">
+
+        <!-- Paso 1: Datos del Remitente -->
+        <q-step :name="1" title="Datos del Remitente" icon="person" :done="step > 1">
+          <q-form @submit.prevent="nextStep">
+            <q-input outlined v-model="form.remitente_nombres" label="Nombres" required />
+            <q-input outlined v-model="form.remitente_apellidos" label="Apellidos" required />
+            <q-input outlined v-model="form.remitente_documento" label="Documento de identidad" required />
+            <q-input outlined v-model="form.remitente_email" label="Correo electrónico" type="email" required />
+            <q-input
+              outlined
+              v-model="form.remitente_celular"
+              label="Celular"
+              type="tel"
+              :rules="[val => /^\d{9}$/.test(val) || 'Debe tener 9 dígitos']"
+              required
+            />
+
+            <div class="q-mt-md">
+              <q-btn label="Siguiente" type="submit" color="primary" />
+            </div>
+          </q-form>
+        </q-step>
+
+        <!-- Paso 2: Datos del Documento -->
+        <q-step :name="2" title="Datos del Documento" icon="description" :done="step > 2">
+          <q-form @submit.prevent="nextStep">
+            <!-- q-select: emit-value hace que v-model guarde SOLO el id (valor numérico). -->
+            <q-select
+              v-model="form.tipo_documento"
+              :options="tiposDocumentoOptions"
+              option-value="id"
+              option-label="nombre"
+              emit-value
+              map-options
+              outlined
+              label="Tipo de documento"
+              dense
+              required
+            />
+            <q-input outlined v-model="form.asunto" label="Asunto" type="textarea" autogrow required />
+
+            <div class="q-mt-md flex justify-between">
+              <q-btn flat label="Atrás" @click="prevStep" />
+              <q-btn label="Siguiente" type="submit" color="primary" />
+            </div>
+          </q-form>
+        </q-step>
+
+        <!-- Paso 3: Adjuntar archivos -->
+        <q-step :name="3" title="Archivos" icon="attach_file" :done="step > 3">
+          <q-form @submit.prevent="nextStep">
+            <!-- File uploader para múltiples archivos -->
+            <q-file
+              v-model="selectedFiles"
+              label="Seleccionar archivos"
+              multiple
+              outlined
+              use-chips
+              accept=".pdf,.jpg,.jpeg,.png,.doc,.docx,.txt,.xlsx,.xls"
+              counter
+              max-files="10"
+              max-file-size="10485760"
+              @rejected="onRejectedFiles"
+              @update:model-value="onFilesSelected"
+            >
+              <template v-slot:prepend>
+                <q-icon name="attach_file" />
+              </template>
+            </q-file>
+
+            <!-- Lista de archivos agregados -->
+            <div v-if="form.archivos.length > 0" class="q-mt-lg">
+              <div class="text-subtitle1 q-mb-md">Archivos agregados:</div>
+              <q-card v-for="(archivo, index) in form.archivos" :key="archivo.id" class="q-mb-sm">
+                <q-card-section class="q-pa-sm">
+                  <div class="row items-center">
+                    <q-icon name="description" class="q-mr-sm" />
+                    <div class="col">
+                      <div class="text-body2">{{ archivo.file.name }}</div>
+                      <div class="text-caption text-grey-6">
+                        {{ formatFileSize(archivo.file.size) }} - {{ archivo.file.type || 'Tipo desconocido' }}
+                      </div>
+                    </div>
+                    <q-btn 
+                      flat 
+                      round 
+                      color="negative" 
+                      icon="delete" 
+                      size="sm"
+                      @click="removeFile(index)"
+                    />
+                  </div>
+                  <q-input 
+                    v-model="archivo.descripcion" 
+                    label="Descripción del archivo (opcional)" 
+                    dense
+                    outlined
+                    class="q-mt-sm"
+                  />
+                </q-card-section>
+              </q-card>
+            </div>
+
+            <!-- Información sobre límites -->
+            <div class="q-mt-md text-caption text-grey-6">
+              <div>• Máximo 10 archivos</div>
+              <div>• Tamaño máximo por archivo: 10 MB</div>
+              <div>• Formatos permitidos: PDF, JPG, PNG, DOC, DOCX, TXT, XLS, XLSX</div>
+            </div>
+
+            <div class="q-mt-md flex justify-between">
+              <q-btn flat label="Atrás" @click="prevStep" />
+              <q-btn label="Siguiente" type="submit" color="primary" />
+            </div>
+          </q-form>
+        </q-step>
+
+        <!-- Paso 4: Confirmación -->
+        <q-step :name="4" title="Confirmación" icon="check_circle">
+          <div class="q-gutter-md">
+            <q-card flat bordered>
+              <q-card-section>
+                <div class="text-h6">Datos del Remitente</div>
+                <p><b>Nombres:</b> {{ form.remitente_nombres }}</p>
+                <p><b>Apellidos:</b> {{ form.remitente_apellidos }}</p>
+                <p><b>DNI:</b> {{ form.remitente_documento }}</p>
+                <p><b>Correo:</b> {{ form.remitente_email }}</p>
+                <p><b>Celular:</b> {{ form.remitente_celular }}</p>
+              </q-card-section>
+            </q-card>
+
+            <q-card flat bordered>
+              <q-card-section>
+                <div class="text-h6">Datos del Documento</div>
+                <!-- mostramos el nombre usando computed tipoDocumentoNombre -->
+                <p><b>Tipo:</b> {{ tipoDocumentoNombre }}</p>
+                <p><b>Asunto:</b> {{ form.asunto }}</p>
+              </q-card-section>
+            </q-card>
+
+            <q-card flat bordered>
+              <q-card-section>
+                <div class="text-h6">Archivos ({{ form.archivos.length }})</div>
+                <div v-if="form.archivos.length > 0">
+                  <div v-for="archivo in form.archivos" :key="archivo.id" class="q-mb-sm">
+                    <q-card flat bordered class="bg-grey-1">
+                      <q-card-section class="q-pa-sm">
+                        <div class="row items-center">
+                          <q-icon name="description" class="q-mr-sm text-primary" />
+                          <div class="col">
+                            <div class="text-body2">{{ archivo.file.name }}</div>
+                            <div class="text-caption text-grey-6">
+                            </div>
+                            <div v-if="archivo.descripcion" class="text-caption q-mt-xs">
+                              <strong>Descripción:</strong> {{ archivo.descripcion }}
+                            </div>
+                          </div>
+                        </div>
+                      </q-card-section>
+                    </q-card>
+                  </div>
+                </div>
+                <div v-else class="text-grey-6">
+                  <q-icon name="info" class="q-mr-sm" />
+                  No se adjuntaron archivos
+                </div>
+              </q-card-section>
+            </q-card>
+          </div>
+
+          <div class="q-mt-md flex justify-between">
+            <q-btn flat label="Atrás" @click="prevStep" />
+            <q-btn 
+              label="Confirmar y Enviar" 
+              color="positive" 
+              @click="submitForm"
+              :loading="submitting"
+              :disable="submitting"
+            />
+          </div>
+        </q-step>
+
+      </q-stepper>
+    </div>
+  </q-page>
+</template>
+
+<script setup>
+import { ref, reactive, onMounted, computed } from 'vue'
+import { Notify } from 'quasar'
+import { api } from 'src/boot/axios'
+import PageTitle from 'src/components/PageTitle.vue'
+
+const step = ref(1)
+const fechaActual = ref(new Date().toISOString().split('T')[0])
+const numeroExpediente = ref('Cargando...')
+const submitting = ref(false)
+const selectedFiles = ref([])
+
+// tipos
+const tiposDocumento = ref([])
+const tiposDocumentoOptions = ref([])
+
+// Contador para IDs únicos de archivos
+let fileIdCounter = 0
+
+async function fetchNumeroExpediente() {
+  try {
+    const { data } = await api.get('/api/tramite/expedientes/next-number/')
+    numeroExpediente.value = data.next_number || data
+  } catch (error) {
+    console.error(error)
+    numeroExpediente.value = 'Error al cargar'
+  }
+}
+
+async function fetchTiposDocumento() {
+  try {
+    const { data } = await api.get('/api/base/tipos-documento-publicos/')
+    tiposDocumento.value = data.results || data
+    tiposDocumentoOptions.value = data.results || data
+    console.log('Tipos documento cargados:', tiposDocumento.value)
+  } catch (error) {
+    console.error('Error al cargar tipos de documento:', error)
+  }
+}
+
+onMounted(() => {
+  fetchNumeroExpediente()
+  fetchTiposDocumento()
+})
+
+const form = reactive({
+  remitente_nombres: '',
+  remitente_apellidos: '',
+  remitente_documento: '',
+  remitente_email: '',
+  remitente_celular: '',
+  tipo_documento: null, // aquí guardamos el ID (number)
+  asunto: '',
+  archivos: [] // Array de objetos 
+})
+
+// computed para mostrar el nombre del tipo seleccionado
+const tipoDocumentoNombre = computed(() => {
+  if (!form.tipo_documento || !tiposDocumento.value.length) return 'No seleccionado'
+  const t = tiposDocumento.value.find(x => x.id === form.tipo_documento)
+  return t ? t.nombre : 'No encontrado'
+})
+
+// Función para formatear el tamaño del archivo
+function formatFileSize(bytes) {
+  if (bytes === 0) return '0 Bytes'
+  const k = 1024
+  const sizes = ['Bytes', 'KB', 'MB', 'GB']
+  const i = Math.floor(Math.log(bytes) / Math.log(k))
+  return parseFloat((bytes / Math.pow(k, i)).toFixed(2)) + ' ' + sizes[i]
+}
+
+// Función para manejar archivos rechazados
+function onRejectedFiles(rejectedEntries) {
+  rejectedEntries.forEach(entry => {
+    let message = `Archivo "${entry.file.name}" rechazado: `
+    if (entry.failedPropValidation === 'max-file-size') {
+      message += 'excede el tamaño máximo (10 MB)'
+    } else if (entry.failedPropValidation === 'accept') {
+      message += 'formato no permitido'
+    } else if (entry.failedPropValidation === 'max-files') {
+      message += 'se alcanzó el límite máximo de archivos'
+    } else {
+      message += 'no cumple con los requisitos'
+    }
+    
+    Notify.create({
+      type: 'negative',
+      message: message,
+      timeout: 4000
+    })
+  })
+}
+
+// Función para manejar cuando se seleccionan archivos 
+function onFilesSelected(files) {
+  if (!files || files.length === 0) {
+    return
+  }
+
+  // Verificar límite total de archivos
+  const totalFiles = form.archivos.length + files.length
+  if (totalFiles > 10) {
+    Notify.create({
+      type: 'negative',
+      message: `No puedes agregar más archivos. Límite máximo: 10 archivos (actualmente tienes ${form.archivos.length})`,
+      timeout: 4000
+    })
+    // Limpiar la selección
+    selectedFiles.value = []
+    return
+  }
+
+  // Agregar cada archivo con un ID único y descripción vacía
+  let addedCount = 0
+  files.forEach(file => {
+    // Verificar si el archivo ya existe (por nombre y tamaño)
+    const exists = form.archivos.some(existing => 
+      existing.file.name === file.name && existing.file.size === file.size
+    )
+
+    if (!exists) {
+      form.archivos.push({
+        id: ++fileIdCounter,
+        file: file,
+        descripcion: ''
+      })
+      addedCount++
+    } else {
+      Notify.create({
+        type: 'warning',
+        message: `El archivo "${file.name}" ya fue agregado`,
+        timeout: 3000
+      })
+    }
+  })
+
+  // Limpiar la selección después de procesar
+  selectedFiles.value = []
+
+  if (addedCount > 0) {
+    Notify.create({
+      type: 'positive',
+      message: `${addedCount} archivo(s) agregado(s) correctamente`,
+      timeout: 2000
+    })
+  }
+}
+
+// Función para remover un archivo
+function removeFile(index) {
+  if (index >= 0 && index < form.archivos.length) {
+    const fileName = form.archivos[index].file.name
+    form.archivos.splice(index, 1)
+    
+    Notify.create({
+      type: 'info',
+      message: `Archivo "${fileName}" eliminado`,
+      timeout: 2000
+    })
+  }
+}
+
+function nextStep() {
+  if (step.value === 2) {
+    if (!form.tipo_documento || !form.asunto || !form.asunto.trim()) {
+      Notify.create({ type: 'negative', message: 'Por favor completa tipo de documento y asunto' })
+      return
+    }
+  }
+  step.value++
+}
+
+function prevStep() {
+  step.value--
+}
+
+async function submitForm() {
+  if (submitting.value) return
+  
+  try {
+    submitting.value = true
+    
+    if (!form.tipo_documento || !form.asunto || !form.asunto.trim()) {
+      Notify.create({ type: 'negative', message: 'Faltan campos requeridos (tipo y asunto)' })
+      return
+    }
+
+    console.log('DEBUG antes de enviar:', { 
+      tipo: form.tipo_documento, 
+      asunto: form.asunto,
+      archivos: form.archivos.length 
+    })
+
+    const fd = new FormData()
+
+    // Remitente: (el backend lee estos campos y crea/recupera Persona automáticamente)
+    fd.append('remitente_nombres', form.remitente_nombres.trim())
+    fd.append('remitente_apellidos', form.remitente_apellidos.trim())
+    fd.append('remitente_documento', form.remitente_documento.trim())
+    fd.append('remitente_email', form.remitente_email.trim())
+    fd.append('remitente_celular', form.remitente_celular.trim())
+
+    // Documento: **clave exacta que espera el backend** -> 'documento[tipo]'
+    fd.append('documento[tipo]', String(form.tipo_documento))
+    fd.append('documento[asunto]', form.asunto.trim())
+
+    // Archivos: lista, cada uno con su descripcion
+    if (form.archivos && form.archivos.length > 0) {
+      form.archivos.forEach((archivoObj, index) => {
+        fd.append(`documento[archivos][${index}][archivo]`, archivoObj.file)
+        fd.append(`documento[archivos][${index}][descripcion]`, archivoObj.descripcion || '')
+      })
+    }
+
+    for (const pair of fd.entries()) {
+      if (pair[1] instanceof File) {
+        console.log('FormData =>', pair[0], `[File: ${pair[1].name}, ${pair[1].size} bytes]`)
+      } else {
+        console.log('FormData =>', pair[0], pair[1])
+      }
+    }
+
+    const response = await api.post('/api/tramite/mesa-partes/', fd, {
+      timeout: 10000, // 10 segundos para archivos grandes
+      onUploadProgress: (progressEvent) => {
+        if (progressEvent.total) {
+          const percentCompleted = Math.round((progressEvent.loaded * 100) / progressEvent.total)
+          console.log(`Upload Progress: ${percentCompleted}%`)
+        }
+      }
+    })
+
+    console.log('Respuesta:', response.data)
+    Notify.create({ 
+      type: 'positive', 
+      message: `Documento registrado correctamente. ${form.archivos.length > 0 ? `Se subieron ${form.archivos.length} archivo(s).` : ''}`,
+      timeout: 5000
+    })
+    
+    resetForm()
+    step.value = 1
+    await fetchNumeroExpediente()
+    
+  } catch (error) {
+    console.error('Error submit:', error)
+    // procesar errores del backend para mostrarlos 
+    let errorMessage = 'Error al registrar documento'
+    
+    if (error.code === 'ECONNABORTED') {
+      errorMessage = 'Tiempo de espera agotado. Los archivos pueden ser demasiado grandes.'
+    } else if (error.response?.data) {
+      // Si es objeto, tratar de armar mensaje
+      const d = error.response.data
+      if (typeof d === 'object') {
+        // priorizar errores dentro de documento
+        if (d.documento) {
+          const parts = []
+          for (const k of Object.keys(d.documento)) {
+            const v = d.documento[k]
+            if (Array.isArray(v)) parts.push(`${k}: ${v.join('; ')}`)
+            else parts.push(`${k}: ${JSON.stringify(v)}`)
+          }
+          if (parts.length) errorMessage += ': ' + parts.join(' | ')
+          else errorMessage += ': ' + JSON.stringify(d)
+        } else {
+          errorMessage += ': ' + JSON.stringify(d)
+        }
+      } else {
+        errorMessage += ': ' + String(d)
+      }
+    }
+    
+    Notify.create({ 
+      type: 'negative', 
+      message: errorMessage, 
+      timeout: 8000,
+      actions: [{
+        label: 'Cerrar',
+        color: 'white'
+      }]
+    })
+  } finally {
+    submitting.value = false
+  }
+}
+
+function resetForm() {
+  Object.assign(form, {
+    remitente_nombres: '',
+    remitente_apellidos: '',
+    remitente_documento: '',
+    remitente_email: '',
+    remitente_celular: '',
+    tipo_documento: null,
+    asunto: '',
+    archivos: []
+  })
+  
+  // Limpiar  la selección temporal
+  selectedFiles.value = []
+  fileIdCounter = 0
+}
+</script>

--- a/src/pages/tramite/MesaDePartes.vue
+++ b/src/pages/tramite/MesaDePartes.vue
@@ -39,10 +39,39 @@
         <!-- Paso 1: Datos del Remitente -->
         <q-step :name="1" title="Datos del Remitente" icon="person" :done="step > 1">
           <q-form @submit.prevent="nextStep">
-            <q-input outlined v-model="form.remitente_nombres" label="Nombres" required />
-            <q-input outlined v-model="form.remitente_apellidos" label="Apellidos" required />
-            <q-input outlined v-model="form.remitente_documento" label="Documento de identidad" required />
-            <q-input outlined v-model="form.remitente_email" label="Correo electrónico" type="email" required />
+            
+            <q-select
+              v-model="form.remitente_tipo_persona"
+              :options="tiposPersonaOptions"
+              option-value="value"
+              option-label="label"
+              emit-value
+              map-options
+              outlined
+              label="Tipo de Persona"
+              dense
+              required
+              class="q-mb-md"
+            />
+
+            <q-select
+              v-model="form.remitente_tipo_doc"
+              :options="tiposDocOptions"
+              option-value="value"
+              option-label="label"
+              emit-value
+              map-options
+              outlined
+              label="Tipo de Documento"
+              dense
+              required
+              class="q-mb-md"
+            />
+
+            <q-input outlined v-model="form.remitente_nombres" label="Nombres" required class="q-mb-md" />
+            <q-input outlined v-model="form.remitente_apellidos" label="Apellidos" required class="q-mb-md" />
+            <q-input outlined v-model="form.remitente_documento" label="Número de documento" required class="q-mb-md" />
+            <q-input outlined v-model="form.remitente_email" label="Correo electrónico" type="email" required class="q-mb-md" />
             <q-input
               outlined
               v-model="form.remitente_celular"
@@ -50,6 +79,7 @@
               type="tel"
               :rules="[val => /^\d{9}$/.test(val) || 'Debe tener 9 dígitos']"
               required
+              class="q-mb-md"
             />
 
             <div class="q-mt-md">
@@ -57,7 +87,6 @@
             </div>
           </q-form>
         </q-step>
-
         <!-- Paso 2: Datos del Documento -->
         <q-step :name="2" title="Datos del Documento" icon="description" :done="step > 2">
           <q-form @submit.prevent="nextStep">
@@ -158,6 +187,8 @@
             <q-card flat bordered>
               <q-card-section>
                 <div class="text-h6">Datos del Remitente</div>
+                <p><b>Tipo de Persona:</b> {{ tipoPersonaLabel }}</p>
+                <p><b>Tipo de Documento:</b> {{ tipoDocLabel }}</p>
                 <p><b>Nombres:</b> {{ form.remitente_nombres }}</p>
                 <p><b>Apellidos:</b> {{ form.remitente_apellidos }}</p>
                 <p><b>DNI:</b> {{ form.remitente_documento }}</p>
@@ -238,6 +269,20 @@ const selectedFiles = ref([])
 const tiposDocumento = ref([])
 const tiposDocumentoOptions = ref([])
 
+const tiposPersonaOptions = ref([
+  { value: '1', label: 'Persona natural' },
+  { value: '2', label: 'Persona jurídica' }
+])
+
+const tiposDocOptions = ref([
+  { value: '1', label: 'DNI' },
+  { value: '2', label: 'RUC' },
+  { value: '3', label: 'Carnet de extranjería' },
+  { value: '4', label: 'Pasaporte' },
+  { value: '5', label: 'Sin documento (Código temporal)' },
+  { value: '6', label: 'Permiso temporal del permanencia' }
+])
+
 // Contador para IDs únicos de archivos
 let fileIdCounter = 0
 
@@ -273,9 +318,11 @@ const form = reactive({
   remitente_documento: '',
   remitente_email: '',
   remitente_celular: '',
-  tipo_documento: null, // aquí guardamos el ID (number)
+  remitente_tipo_persona: '1', //  default Persona natural
+  remitente_tipo_doc: '1',     // default DNI
+  tipo_documento: null,       // aquí guardamos el ID 
   asunto: '',
-  archivos: [] // Array de objetos 
+  archivos: [] 
 })
 
 // computed para mostrar el nombre del tipo seleccionado
@@ -283,6 +330,16 @@ const tipoDocumentoNombre = computed(() => {
   if (!form.tipo_documento || !tiposDocumento.value.length) return 'No seleccionado'
   const t = tiposDocumento.value.find(x => x.id === form.tipo_documento)
   return t ? t.nombre : 'No encontrado'
+})
+
+const tipoPersonaLabel = computed(() => {
+  const tipo = tiposPersonaOptions.value.find(x => x.value === form.remitente_tipo_persona)
+  return tipo ? tipo.label : 'No seleccionado'
+})
+
+const tipoDocLabel = computed(() => {
+  const tipo = tiposDocOptions.value.find(x => x.value === form.remitente_tipo_doc)
+  return tipo ? tipo.label : 'No seleccionado'
 })
 
 // Función para formatear el tamaño del archivo
@@ -424,6 +481,9 @@ async function submitForm() {
     fd.append('remitente_documento', form.remitente_documento.trim())
     fd.append('remitente_email', form.remitente_email.trim())
     fd.append('remitente_celular', form.remitente_celular.trim())
+    fd.append('remitente_tipo_persona', form.remitente_tipo_persona) 
+    fd.append('remitente_tipo_doc', form.remitente_tipo_doc)         
+
 
     // Documento: **clave exacta que espera el backend** -> 'documento[tipo]'
     fd.append('documento[tipo]', String(form.tipo_documento))
@@ -516,6 +576,9 @@ function resetForm() {
     remitente_documento: '',
     remitente_email: '',
     remitente_celular: '',
+    remitente_tipo_persona: '1', // default
+    remitente_tipo_doc: '1',     //  default
+
     tipo_documento: null,
     asunto: '',
     archivos: []

--- a/src/pages/tramite/NuevoDocumentoPage.vue
+++ b/src/pages/tramite/NuevoDocumentoPage.vue
@@ -357,9 +357,10 @@ const submitForm = async () => {
     formData.append('documento[tipo]', info.tipo_documento?.id || info.tipo_documento || '')
     formData.append('documento[remitente]', persona.value.id)
     formData.append('documento[numero]', info.numero)
+    debugger
     formData.append(
       'documento[asignacion_cargo]',
-      persona.value.asignaciones_cargo?.find((a) => a.oficina === info.oficina?.value)?.id || '',
+      persona.value.asignaciones_cargo?.find((a) => a.oficina_nombre === info.oficina)?.id || '',
     )
     formData.append('documento[asunto]', info.asunto)
     formData.append('documento[resumen]', '')

--- a/src/pages/tramite/ResponderDocumentoPage.vue
+++ b/src/pages/tramite/ResponderDocumentoPage.vue
@@ -9,17 +9,16 @@
             <SimpleTitle title="Información" />
             <q-input
               outlined
+              readonly
               required
               v-model="info.expediente"
               label="Expediente"
               maxlength="50"
               :error-message="errores_texto.expediente"
               :error="errores.expediente"
-              readonly
             />
             <q-input
               outlined
-              type="date"
               required
               v-model="info.fecha_expediente"
               label="Fecha expediente"
@@ -37,40 +36,15 @@
               :error="errores.remitente"
               readonly
             />
-
-            <!-- Oficina: readonly, vacío con mensaje, o APISelect -->
-            <template v-if="oficinaOptions.readonly">
-              <q-input
-                outlined
-                required
-                v-model="info.oficina"
-                label="Oficina"
-                maxlength="255"
-                :error-message="errores_texto.oficina"
-                :error="errores.oficina"
-                readonly
-              />
-              <q-banner
-                v-if="oficinaOptions.showNoOficinaMsg"
-                class="q-mt-sm"
-                color="negative"
-                dense
-              >
-                No tiene oficinas asignadas
-              </q-banner>
-            </template>
-            <q-select
-              v-else
+            <q-input
               outlined
-              label="Oficina"
+              required
               v-model="info.oficina"
-              :options="oficinaOptions.options"
-              option-label="label"
-              option-value="value"
+              label="Oficina"
+              maxlength="255"
               :error-message="errores_texto.oficina"
               :error="errores.oficina"
-              dense
-              clearable
+              readonly
             />
 
             <!-- Tipo de documento -->
@@ -121,45 +95,15 @@
               :error-message="errores_texto.asunto"
               :error="errores.asunto"
             />
-            <SimpleTitle title="Destinatarios" />
-            <div v-for="(dest, index) in info.destinatarios" :key="index" class="q-mb-md">
-              <div class="row items-center">
-                <div class="col">
-                  <APISelect
-                    v-model="info.destinatarios[index]"
-                    label="Destinatario"
-                    :url="urlPersonasConOficina"
-                    :field="
-                      (item) =>
-                        `${item.persona.nombre_completo}: ${item.cargo.nombre} de ${item.oficina.nombre}`
-                    "
-                    :option-value="(item) => item"
-                    option-label="nombre_completo"
-                    dense
-                    :return-object="true"
-                    :error-message="errores_texto[`destinatarios.${index}`]"
-                    :error="errores[`destinatarios.${index}`]"
-                  />
-                </div>
-                <div class="col-auto">
-                  <q-btn
-                    dense
-                    flat
-                    round
-                    icon="delete"
-                    color="negative"
-                    @click="removeDestinatario(index)"
-                  />
-                </div>
-              </div>
-            </div>
+            <SimpleTitle title="Destinatario" />
 
-            <q-btn
-              flat
-              color="primary"
-              icon="add"
-              label="Añadir destinatario"
-              @click="addDestinatario"
+            <q-input
+              outlined
+              required
+              :model-value="`${info.destinatarios[0]?.persona.nombre_completo} - ${info.destinatarios[0]?.oficina.nombre}`"
+              label="Destinatario"
+              maxlength="255"
+              readonly
             />
 
             <SimpleTitle title="Archivos" />
@@ -194,8 +138,8 @@
 
 <script setup>
 import { reactive, onMounted, watch, ref } from 'vue'
-import { Notify, Loading} from 'quasar'
-import { useRouter } from 'vue-router'
+import { Notify } from 'quasar'
+import { useRouter, useRoute } from 'vue-router'
 import { api } from 'src/boot/axios'
 import { usePersonaStore } from 'src/stores/persona'
 import PageTitle from 'src/components/PageTitle.vue'
@@ -203,12 +147,12 @@ import APISelect from 'src/components/APISelect.vue'
 import SimpleTitle from 'src/components/SimpleTitle.vue'
 
 const router = useRouter()
-
+const route = useRoute()
 const personaStore = usePersonaStore()
 
 const titulo = reactive({
-  title: 'Nuevo Documento',
-  icon: 'description',
+  title: 'Responder Documento',
+  icon: 'reply',
   buttons: [{ label: 'Ver todos los Documentos', icon: 'list', route: '/documentos' }],
 })
 
@@ -221,7 +165,7 @@ const info = reactive({
   numero: '',
   fecha_documento: '',
   asunto: '',
-  destinatarios: [null],
+  destinatarios: [],
   archivos: [],
   archivosDescripciones: [],
 })
@@ -231,12 +175,7 @@ const persona = ref({})
 const errores = reactive({})
 const errores_texto = reactive({})
 
-const endpoint = '/api/tramite/expedientes/completo/'
-
-const urlPersonasConOficina = '/api/base/personas-con-oficina/'
-
 const today = new Date().toISOString().slice(0, 10)
-info.fecha_expediente = today
 info.fecha_documento = today
 
 const oficinaOptions = reactive({
@@ -244,6 +183,65 @@ const oficinaOptions = reactive({
   showNoOficinaMsg: false,
   options: [],
 })
+
+// Format for date display
+function formatFecha(fecha) {
+  if (!fecha) return ''
+  const date = new Date(fecha)
+  return date.toLocaleDateString('es-PE', {
+    day: '2-digit',
+    month: '2-digit',
+    year: 'numeric',
+  }) /* +
+    ' ' +
+    date.toLocaleTimeString('es-PE', {
+      hour: '2-digit',
+      minute: '2-digit',
+    })*/
+}
+
+// Datos de documento a responder
+async function fetchDocumento() {
+  try {
+    const id = route.params.id
+    const res = await api.get(`/api/tramite/documentos/${id}/`)
+    const data = res.data
+    console.log('Documento data:', data)
+
+    // Llenar info del documento (expediente, fecha-expediente, remitente, oficina, destinatario)
+
+    // Documento padre
+    info.documento_padre = data.id || null
+
+    // Expediente (se mantiene igual)
+    info.expediente_id = data.expediente || ''
+    info.expediente = data.expediente_numero || ''
+    info.fecha_expediente = formatFecha(data.expediente_fecha) || ''
+
+    // Remitente: será el usuario actual, lo seteamos en fetchPersonaActual()
+    // Solo dejamos espacio para mostrar en pantalla el original (si quieres)
+    info.remitente_original = data.remitente_nombre || ''
+    info.oficina_original = data.remitente_oficina || ''
+
+    // Nuevo destinatario = remitente original
+    info.destinatarios = [
+      {
+        persona: { id: data.remitente, nombre_completo: data.remitente_nombre },
+        oficina: { id: data.remitente_oficina, nombre: data.remitente_oficina_nombre },
+      },
+    ]
+
+    console.log('info: ', info)
+    //console.log(info)
+  } catch (error) {
+    console.error('Error al obtener documento:', error)
+    Notify.create({
+      type: 'negative',
+      message: 'No se pudo cargar el documento',
+    })
+    router.push('/bandeja/salida')
+  }
+}
 
 async function fetchPersonaActual() {
   try {
@@ -280,33 +278,6 @@ async function fetchPersonaActual() {
   }
 }
 
-function addDestinatario() {
-  info.destinatarios.push(null)
-}
-function removeDestinatario(index) {
-  if (info.destinatarios.length > 1) {
-    info.destinatarios.splice(index, 1)
-  } else {
-    Notify.create({
-      type: 'warning',
-      message: 'Debe haber al menos un destinatario',
-    })
-  }
-}
-
-async function fetchNumeroExpediente() {
-  try {
-    const res = await api.get('/api/tramite/expedientes/next-number/')
-    info.expediente = res.data.next_number
-  } catch (error) {
-    console.error('Error al obtener número de expediente:', error)
-    Notify.create({
-      type: 'negative',
-      message: 'No se pudo obtener el número de expediente',
-    })
-  }
-}
-
 async function fetchNumeroDocumento(tipo_id) {
   if (!tipo_id) {
     info.numero = ''
@@ -328,7 +299,7 @@ async function fetchNumeroDocumento(tipo_id) {
 }
 
 onMounted(() => {
-  fetchNumeroExpediente()
+  fetchDocumento()
   fetchPersonaActual()
 })
 
@@ -339,52 +310,92 @@ watch(
   },
 )
 
+// ... dentro de <script setup>
+
 const submitForm = async () => {
+  // Limpia los errores existentes
   Object.keys(errores).forEach((k) => (errores[k] = false))
   Object.keys(errores_texto).forEach((k) => (errores_texto[k] = ''))
-  
+
   try {
-    Loading.show({
-    message: 'Guardando documento...',
-    spinnerColor: 'white'
-  })
-
     const formData = new FormData()
-    formData.append('numero', info.expediente)
-    formData.append('estado', 'Abierto')
-    formData.append('responsable', persona.value.id)
 
-    formData.append('documento[tipo]', info.tipo_documento?.id || info.tipo_documento || '')
-    formData.append('documento[remitente]', persona.value.id)
-    formData.append('documento[numero]', info.numero)
-    formData.append(
-      'documento[asignacion_cargo]',
-      persona.value.asignaciones_cargo?.find((a) => a.oficina === info.oficina?.value)?.id || '',
-    )
-    formData.append('documento[asunto]', info.asunto)
-    formData.append('documento[resumen]', '')
-    formData.append('documento[es_informativo]', false)
+    // 1. Obtener el ID del expediente
+    // Asume que el ID del expediente original está disponible en 'info.expediente_id'
+    // Si no lo tienes, deberás ajustarlo en fetchDocumento() para obtener el ID real.
+    const expedienteId = info.expediente_id // <-- CAMBIO CLAVE
 
-    info.destinatarios
-      .filter((d) => d.persona !== null)
-      .forEach((dest, index) => {
-        formData.append(`documento[destinos_documento][${index}][destinatario]`, dest.persona.id)
-        formData.append(`documento[destinos_documento][${index}][oficina_destino]`, dest.oficina.id)
+    // 2. Apuntar al endpoint correcto
+    const endpoint = `/api/tramite/expedientes/${expedienteId}/documentos/`
+
+    // 3. Agregar los campos del documento al FormData
+    // Los campos ya no necesitan el prefijo 'documento[...]' si tu backend
+    // lo espera directamente en el payload principal.
+    // Si tu backend espera 'documento[...]', mantén la estructura.
+
+    // Si usas JSON como en la última implementación:
+    const payload = {
+      numero: info.numero,
+      tipo: info.tipo_documento,
+      remitente: persona.value.id,
+      asignacion_cargo: persona.value.asignaciones_cargo?.find(
+        (a) => a.oficina_nombre === info.oficina,
+      )?.id,
+      documento_padre: info.documento_padre,
+      asunto: info.asunto,
+      resumen: info.resumen, // Asegúrate de que este campo exista en tu reactive
+      es_informativo: false, // O el valor que corresponda
+      destinos_documento: info.destinatarios.map((d) => ({
+        destinatario: d.persona.id,
+        oficina_destino: d.oficina.id,
+        es_delegacion: false, // O el valor que corresponda
+      })),
+    }
+    console.log(payload)
+
+    // Manejar el caso de multipart/form-data con archivos
+    if (info.archivos && info.archivos.length > 0) {
+      // Si hay archivos, usamos FormData
+      formData.append('numero', info.numero || '')
+      formData.append('tipo', info.tipo_documento || '')
+      formData.append('remitente', persona.value.id)
+      formData.append(
+        'asignacion_cargo',
+        persona.value.asignaciones_cargo?.find((a) => a.oficina_nombre === info.oficina)?.id || '',
+      )
+      formData.append('documento_padre', info.documento_padre || '')
+      formData.append('asunto', info.asunto)
+      formData.append('resumen', info.resumen)
+      formData.append('es_informativo', false)
+
+      info.destinatarios.forEach((dest, index) => {
+        formData.append(`destinos_documento[${index}][destinatario]`, dest.persona.id)
+        formData.append(`destinos_documento[${index}][oficina_destino]`, dest.oficina.id)
+        formData.append(`destinos_documento[${index}][es_delegacion]`, false) // faltaba
       })
 
-    info.archivos.forEach((file, index) => {
-      formData.append(`documento[archivos][${index}][archivo]`, file)
-      formData.append(
-        `documento[archivos][${index}][descripcion]`,
-        info.archivosDescripciones[index] || '',
-      )
-    })
+      info.archivos.forEach((file, index) => {
+        formData.append(`documento[archivos][${index}][archivo]`, file)
+        formData.append(
+          `documento[archivos][${index}][descripcion]`,
+          info.archivosDescripciones[index] || '',
+        )
+      })
 
-    const response = await api.post(endpoint, formData, {
-      headers: { 'Content-Type': 'multipart/form-data' },
-    })
-    console.log('Documento creado:', response.data)
+      const obj = Object.fromEntries(formData.entries())
+      console.log('Formdata generado: ', obj)
 
+      const response = await api.post(endpoint, formData, {
+        headers: { 'Content-Type': 'multipart/form-data' },
+      })
+      console.log('Documento creado:', response.data)
+    } else {
+      // Si no hay archivos, podemos usar JSON puro
+      const response = await api.post(endpoint, payload)
+      console.log('Documento creado:', response.data)
+    }
+
+    // Notificación de éxito y redirección
     Notify.create({
       type: 'positive',
       message: 'Documento creado con éxito',
@@ -405,9 +416,6 @@ const submitForm = async () => {
       type: 'negative',
       message: 'Revisa los errores en el formulario',
     })
-  }
-  finally {
-    Loading.hide()
   }
 }
 </script>

--- a/src/pages/tramite/SeguimientoExpedientePage.vue
+++ b/src/pages/tramite/SeguimientoExpedientePage.vue
@@ -1,0 +1,93 @@
+<template>
+  <q-page class="q-pa-md">
+    <div class="row items-center q-mb-md">
+      <div class="col">
+        <div class="text-h6">Seguimiento del expediente {{ numero }}</div>
+        <div class="text-caption text-grey-7" v-if="expediente?.numero">
+          N° {{ expediente.numero }}
+        </div>
+      </div>
+      <div class="col-auto">
+        <q-btn dense flat icon="refresh" :loading="loading" @click="fetchData" />
+      </div>
+    </div>
+
+    <q-card flat bordered>
+      <q-card-section>
+        <q-timeline color="primary">
+          <q-timeline-entry
+            v-for="(ev, idx) in events"
+            :key="idx"
+            :title="ev.label"
+            :subtitle="formatDate(ev.ts)"
+            :icon="iconFor(ev.kind)"
+          >
+            <div class="text-caption">
+              <div v-if="ev.doc_id" class="row items-center no-wrap">
+                <div><b>Documento:</b> {{ ev.doc_tipo }} {{ ev.doc_numero }}</div>
+                <q-btn
+                  dense
+                  flat
+                  round
+                  size="sm"
+                  icon="visibility"
+                  class="q-ml-sm"
+                  @click="goToDocumento(ev.doc_id)"
+                />
+              </div>
+
+              <div v-if="ev.doc_asunto"><b>Asunto:</b> {{ ev.doc_asunto }}</div>
+              <div v-if="ev.destino_id"><b>Destino:</b> {{ ev.destino_oficina }}</div>
+              <div v-if="ev.estado"><b>Estado:</b> {{ ev.estado_nombre }}</div>
+            </div>
+          </q-timeline-entry>
+        </q-timeline>
+      </q-card-section>
+    </q-card>
+  </q-page>
+</template>
+
+<script setup>
+import { onMounted, ref, computed } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+import { api } from 'boot/axios'
+
+const route = useRoute()
+const router = useRouter()
+const numero = computed(() => route.params.numero)
+
+const loading = ref(false)
+const expediente = ref(null)
+const events = ref([])
+
+function formatDate(iso) {
+  try {
+    return new Date(iso).toLocaleString()
+  } catch {
+    return iso
+  }
+}
+function iconFor(kind) {
+  if (kind === 'movimiento') return 'swap_horiz'
+  if (kind === 'destino') return 'send'
+  if (kind === 'estado') return 'flag'
+  return 'event'
+}
+
+async function fetchData() {
+  loading.value = true
+  try {
+    const { data } = await api.get(`/api/tramite/expedientes/${numero.value}/seguimiento/`)
+    expediente.value = data.expediente
+    events.value = (data.events || []).slice().sort((a, b) => a.ts.localeCompare(b.ts))
+  } finally {
+    loading.value = false
+  }
+}
+
+function goToDocumento(id) {
+  router.push(`/documento/${id}`)
+}
+
+onMounted(fetchData)
+</script>

--- a/src/router/routes.js
+++ b/src/router/routes.js
@@ -79,6 +79,11 @@ const routes = [
         component: () => import('src/pages/tramite/ResponderDocumentoPage.vue'),
         props: true,
       },
+      {
+        path: 'expediente/:numero/seguimiento',
+        component: () => import('src/pages/tramite/SeguimientoExpedientePage.vue'),
+        props: true,
+      },
     ],
     meta: { requiresAuth: true },
   },

--- a/src/router/routes.js
+++ b/src/router/routes.js
@@ -74,6 +74,11 @@ const routes = [
         component: () => import('src/pages/tramite/DocumentoPage.vue'),
         props: true,
       },
+      {
+        path: 'documento/responder/:id',
+        component: () => import('src/pages/tramite/ResponderDocumentoPage.vue'),
+        props: true,
+      },
     ],
     meta: { requiresAuth: true },
   },

--- a/src/router/routes.js
+++ b/src/router/routes.js
@@ -87,6 +87,18 @@ const routes = [
     ],
     meta: { requiresAuth: true },
   },
+
+  {
+    path: '/mesa-de-partes',
+    component: () => import('layouts/MainLayout.vue'),
+    children: [
+      {
+        path: '',
+        component: () => import('src/pages/tramite/MesaDePartes.vue')
+      }
+    ]
+  },
+  
   {
     path: '/login',
     component: () => import('layouts/AuthLayout.vue'),


### PR DESCRIPTION
### Agregar campos tipo_doc y tipo_persona al formulario Mesa de Partes #85 

**Cambios realizados:**
Nuevos q-select en Paso 1:
Tipo de Persona: Natural/Jurídica
Tipo de Documento: DNI/RUC/Carnet/etc.

**Mejoras de UX:**
Ancho consistente (max-width: 600px) en todos los campos
Espaciado uniforme con **q-gutter-md**
Reset automático a valores por defecto

**Envío al backend:**
javascriptfd.append('remitente_tipo_persona', form.remitente_tipo_persona)
fd.append('remitente_tipo_doc', form.remitente_tipo_doc)
Manejo de errores mejorado:ªª

**Manejo de errores mejorado:**
Timeout aumentado a 30s

Pruebas:
<img width="1653" height="873" alt="image" src="https://github.com/user-attachments/assets/f69b527e-c202-4b74-a9c2-90458074dc92" />

<img width="1803" height="479" alt="Captura desde 2025-09-05 18-31-44" src="https://github.com/user-attachments/assets/4fc36f37-7281-420c-bffa-eb6e2d7caea8" />

