### PR TITLE
feat/listado de expedientes

### DIFF
--- a/src/pages/tramite/ExpedientesPage.vue
+++ b/src/pages/tramite/ExpedientesPage.vue
@@ -1,0 +1,96 @@
+<template>
+  <ListPage :titulo="titulo" :table="table" />
+</template>
+
+<script setup>
+import { ref, computed } from 'vue'
+import ListPage from 'src/components/ListPage.vue'
+import router from 'src/router'
+
+const titulo = {
+  title: 'Expedientes',
+  icon: 'folder',
+}
+
+// Acciones múltiples por fila (solo Ver en este caso)
+const multiActions = ref([
+  {
+    label: 'Ver seguimiento',
+    icon: 'visibility',
+    action: (row) => {
+      router.push(`/expediente/${row.id}/seguimiento`)
+      // console.log('Ver acción ejecutada', row.id)
+      // can use router.push
+    },
+  },
+])
+
+// Columnas de la tabla
+const columns = [
+  {
+    name: 'numero',
+    label: 'Número',
+    align: 'left',
+    field: 'numero',
+    sortable: true,
+  },
+  {
+    name: 'fecha',
+    label: 'Fecha de creación',
+    align: 'left',
+    field: 'fecha',
+    format: (val) => new Date(val).toLocaleDateString(),
+    sortable: true,
+  },
+  {
+    name: 'responsable',
+    label: 'Responsable',
+    align: 'left',
+    field: 'responsable_nombre',
+    sortable: true,
+  },
+  {
+    name: 'estado',
+    label: 'Estado',
+    align: 'left',
+    field: 'estado_display',
+    sortable: true,
+  },
+  {
+    name: 'multiactions',
+    label: 'Acciones',
+    align: 'center',
+  },
+]
+
+const filters = [
+  {
+    label: 'Estado',
+    type: 'select',
+    field: 'estado',
+    options: [
+      { label: 'Todos', value: '' },
+      { label: 'Abierto', value: '1' },
+      { label: 'Cerrado', value: '2' },
+      { label: 'Archivado', value: '3' },
+    ],
+  },
+  {
+    label: 'Número',
+    type: 'text',
+    field: 'numero',
+  },
+  {
+    label: 'Fecha',
+    type: 'date-range',
+    field: 'fecha',
+  },
+]
+
+const table = computed(() => ({
+  endpoint: '/api/tramite/expedientes/',
+  columns,
+  multiActions: multiActions.value,
+  filters,
+}))
+</script>

--- a/src/router/routes.js
+++ b/src/router/routes.js
@@ -84,6 +84,10 @@ const routes = [
         component: () => import('src/pages/tramite/SeguimientoExpedientePage.vue'),
         props: true,
       },
+      {
+        path: 'expedientes',
+        component: () => import('src/pages/tramite/ExpedientesPage.vue'),
+      },
     ],
     meta: { requiresAuth: true },
   },
@@ -94,11 +98,11 @@ const routes = [
     children: [
       {
         path: '',
-        component: () => import('src/pages/tramite/MesaDePartes.vue')
-      }
-    ]
+        component: () => import('src/pages/tramite/MesaDePartes.vue'),
+      },
+    ],
   },
-  
+
   {
     path: '/login',
     component: () => import('layouts/AuthLayout.vue'),


### PR DESCRIPTION
### **Descripción**
Se implementa la vista de listado de expedientes consumiendo el endpoint `/api/tramite/expedientes/`. Incluye tabla con filtros, columnas personalizadas y acciones por fila (navegar al seguimiento del expediente).
### **Cambios técnicos**
Se creó el componente de listado basado en `ListPage`.
Definición de columnas: número, fecha de creación (formateada), responsable y estado (con `estado_display`).
Se agregó columna de acciones con opción "Ver seguimiento" que redirige vía `router.push` a `/expediente/{id}/seguimiento`.
Se añadieron filtros:
- Select de estado (Todos, Abierto, Cerrado, Archivado).
- Texto para número.
- Rango de fechas para fecha de creación.

### **Capturas de Pantalla**
<img width="1536" height="470" alt="image" src="https://github.com/user-attachments/assets/2e2ffbfa-877f-41d8-93ac-7f8aee39ca82" />

### **Issue Relacionado**
#95 