### PR TITLE
fix/se quitaron los botones de redirección a listado de documentos

### DIFF
--- a/src/pages/tramite/NuevoDocumentoPage.vue
+++ b/src/pages/tramite/NuevoDocumentoPage.vue
@@ -194,7 +194,7 @@
 
 <script setup>
 import { reactive, onMounted, watch, ref } from 'vue'
-import { Notify, Loading} from 'quasar'
+import { Notify, Loading } from 'quasar'
 import { useRouter } from 'vue-router'
 import { api } from 'src/boot/axios'
 import { usePersonaStore } from 'src/stores/persona'
@@ -209,7 +209,6 @@ const personaStore = usePersonaStore()
 const titulo = reactive({
   title: 'Nuevo Documento',
   icon: 'description',
-  buttons: [{ label: 'Ver todos los Documentos', icon: 'list', route: '/documentos' }],
 })
 
 const info = reactive({
@@ -342,12 +341,12 @@ watch(
 const submitForm = async () => {
   Object.keys(errores).forEach((k) => (errores[k] = false))
   Object.keys(errores_texto).forEach((k) => (errores_texto[k] = ''))
-  
+
   try {
     Loading.show({
-    message: 'Guardando documento...',
-    spinnerColor: 'white'
-  })
+      message: 'Guardando documento...',
+      spinnerColor: 'white',
+    })
 
     const formData = new FormData()
     formData.append('numero', info.expediente)
@@ -406,8 +405,7 @@ const submitForm = async () => {
       type: 'negative',
       message: 'Revisa los errores en el formulario',
     })
-  }
-  finally {
+  } finally {
     Loading.hide()
   }
 }

--- a/src/pages/tramite/ResponderDocumentoPage.vue
+++ b/src/pages/tramite/ResponderDocumentoPage.vue
@@ -153,7 +153,6 @@ const personaStore = usePersonaStore()
 const titulo = reactive({
   title: 'Responder Documento',
   icon: 'reply',
-  buttons: [{ label: 'Ver todos los Documentos', icon: 'list', route: '/documentos' }],
 })
 
 const info = reactive({


### PR DESCRIPTION
### **Descripción**
Se quitaron los botones de `Ver todos los documentos` en la creación y respuesta de documentos, porque el listado de documentos como tal no existe.
### **Cambios técnicos**
Se modificaron los componentes `src/pages/tramite/NuevoDocumentoPage.vue` y `src/pages/tramite/ResponderDocumentoPage.vue`, eliminando el atributo `buttons` de la constante `titulo` para `PageTitle`.
### **Capturas de pantalla**
<img width="428" height="155" alt="image" src="https://github.com/user-attachments/assets/7c02929f-2f59-49f1-a354-f48140f6c709" />
<img width="1847" height="374" alt="image" src="https://github.com/user-attachments/assets/c54c28b9-0c96-467d-b5df-82fb71c8436e" />

<img width="1847" height="374" alt="image" src="https://github.com/user-attachments/assets/a498af21-c1d5-4114-99d8-6c33673226f0" />


### **Issue Relacionado**
#100 
