### PR TITLE
Seguimiento publico final

### DIFF
--- a/src/pages/tramite/SeguimientoPublico.vue
+++ b/src/pages/tramite/SeguimientoPublico.vue
@@ -153,7 +153,7 @@ const columns = [
 ]
 
 function verSeguimiento(row) {
-  router.push(`/expediente/${row.numero}/seguimiento`)
+  router.push(`/expediente/${row.numero}/seguimiento-publico`)
 }
 
 async function buscar() {

--- a/src/router/routes.js
+++ b/src/router/routes.js
@@ -114,13 +114,13 @@ const routes = [
     ],
   },
   {
-    path: '/expediente/:numero/seguimiento',
+    path: '/expediente/:numero/seguimiento-publico',
     component: () => import('layouts/MainLayout.vue'),
     children: [
       {
         path: '',
         component: () => import('src/pages/tramite/SeguimientoExpedientePage.vue'),
-        props: true,
+        meta: { requiresAuth: false },
       },
     ],
   },


### PR DESCRIPTION
##  Seguimiento público de expedientes

###  Cambios realizados
- Se agregó formulario de búsqueda pública de expedientes por:
  - Número de expediente
  
<img width="769" height="731" alt="image" src="https://github.com/user-attachments/assets/89e48df0-f01e-4ef5-8e9a-cfaff0c12dfc" />

  - Tipo y número de documento
  
<img width="769" height="731" alt="image" src="https://github.com/user-attachments/assets/98752bcc-0e97-4005-aec1-b97fe1fd667f" />

- Se implementó tabla de resultados con opción **"Ver"** que redirige a la ruta pública:

<img width="782" height="731" alt="image" src="https://github.com/user-attachments/assets/c7cf6df0-4f6d-4b76-a8c3-eb27e56171b1" />

Closes #103 
