### PR TITLE
fix/Mejoras en VerDocumento.vue

### DIFF
--- a/src/pages/tramite/DocumentoPage.vue
+++ b/src/pages/tramite/DocumentoPage.vue
@@ -207,7 +207,7 @@ async function fetchDocumento() {
     info.expediente = data.expediente_numero || ''
     info.fecha_expediente = formatFecha(data.expediente_fecha) || ''
     info.remitente = data.remitente_nombre || ''
-    info.oficina = data.remitente_oficina || ''
+    info.oficina = data.remitente_oficina_nombre || ''
     info.tipo_documento = data.tipo_nombre // puedes poner objeto o solo id
     info.numero = data.numero
     info.fecha_documento = formatFecha(data.fecha)


### PR DESCRIPTION
### **Descripción**
Se cambió el tipo de variable para mostrar los datos de un documento, y ahora se muestra el nombre de la oficina y no su id en el campo de oficina del remitente.
### **Cambios técnicos**
Se modificó el archivo `src/pages/tramite/DocumentoPage.vue` para:
- Incluir cajas de texto `div` en lugar de las `q-input` con propiedad de solo lectura. La estructura HTML general fue modificada y se añadió un apartado `<styles>` para que sea vea mejor la información presente en la página. 
- Cambiar el campo al que oficina del remitente hace referencia. En lugar de `remitente_oficina`, se recupera `remitente_oficina_nombre` del endpoint `api/tramite/documentos/:id/` para el valor de `info.oficina` que será recuperado para el campo de Oficina en la estructura HTML.
### **Capturas de Pantalla**
<img width="1846" height="705" alt="image" src="https://github.com/user-attachments/assets/d186f19b-e6ff-4ebd-8319-aec568afd49e" />

### **Issues Relacionados**
#101 
#107 