### PR TITLE
Seguimiento publico corregido

### DIFF
--- a/src/pages/tramite/SeguimientoPublico.vue
+++ b/src/pages/tramite/SeguimientoPublico.vue
@@ -153,7 +153,11 @@ const columns = [
 ]
 
 function verSeguimiento(row) {
-  router.push(`/expediente/${row.numero}/seguimiento-publico`)
+  if (row.id) {
+    router.push(`/expediente/${row.id}/seguimiento`)
+  } else {
+    Notify.create({ type: 'negative', message: 'No se encontró el ID del expediente' })
+  }
 }
 
 async function buscar() {

--- a/src/router/routes.js
+++ b/src/router/routes.js
@@ -114,7 +114,7 @@ const routes = [
     ],
   },
   {
-    path: '/expediente/:numero/seguimiento-publico',
+    path: '/expediente/:id/seguimiento-publico',
     component: () => import('layouts/MainLayout.vue'),
     children: [
       {


### PR DESCRIPTION
# Corregit el frontend de Seguimiento Publico

##  Cambios
- Formulario de búsqueda por **número de expediente** o **documento**.
- Tabla de resultados con columnas: número, fecha, estado y acciones.
- Botón **Ver** redirige a `/expediente/{id}/seguimiento-publico`.

<img width="777" height="726" alt="image" src="https://github.com/user-attachments/assets/7898815e-a303-4113-af5d-5051d2dac26d" />

<img width="777" height="726" alt="image" src="https://github.com/user-attachments/assets/a203c283-de2b-48bc-b5fa-9bbacf057cd1" />

## Resultado
Interfaz  de seguimiento publico funcional

## Observaciones
Falta modificar el backend para hacer publico el endpoint de **api/tramite/seguimiento/publico/**

Closes #109 
